### PR TITLE
Fix Python 3 incompatibilities

### DIFF
--- a/redbeat/__init__.py
+++ b/redbeat/__init__.py
@@ -1,1 +1,3 @@
-from redbeat.schedulers import RedBeatScheduler, RedBeatSchedulerEntry  # noqa
+from __future__ import absolute_import
+
+from .schedulers import RedBeatScheduler, RedBeatSchedulerEntry  # noqa

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -23,9 +23,10 @@ class test_RedBeatEntry(RedBeatCase):
             'options': {},
             'enabled': True,
         }
+        expected_key = (self.app.conf.REDBEAT_KEY_PREFIX + 'test').encode('utf-8')
 
         redis = self.app.redbeat_redis
-        value = redis.hget(self.app.conf.REDBEAT_KEY_PREFIX + 'test', 'definition')
+        value = redis.hget(expected_key, 'definition').decode('utf8')
         self.assertEqual(expected, json.loads(value, cls=RedBeatJSONDecoder))
         self.assertEqual(redis.zrank(self.app.conf.REDBEAT_SCHEDULE_KEY, e.key), 0)
         self.assertEqual(redis.zscore(self.app.conf.REDBEAT_SCHEDULE_KEY, e.key), e.score)


### PR DESCRIPTION
* Changes absolute import to relative.
* Handles Redis values being returned as bytes.
* Removes usage of `unicode()` in logging call.

Signed-off-by: Christopher Arndt <christopher.arndt@rheinwerk-verlag.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/33)
<!-- Reviewable:end -->
