### PR TITLE
Fix error when deleting old schedule entries.

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -195,7 +195,9 @@ class RedBeatScheduler(Scheduler):
                        for key in client.smembers(self.app.conf.REDBEAT_STATICS_KEY))
         removed = previous.difference(self.app.conf.CELERYBEAT_SCHEDULE.keys())
         for name in removed:
+            logger.debug("Removing old schedule entry '%s'.", name)
             RedBeatSchedulerEntry(name, app=self.app).delete()
+            client.srem(self.app.conf.REDBEAT_STATICS_KEY, name)
 
         # setup statics
         self.install_default_entries(self.app.conf.CELERYBEAT_SCHEDULE)

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -191,9 +191,9 @@ class RedBeatScheduler(Scheduler):
     def setup_schedule(self):
         # cleanup old static schedule entries
         client = redis(self.app)
-        previous = set(key.decode('utf-8')
-                       for key in client.smembers(self.app.conf.REDBEAT_STATICS_KEY))
+        previous = set(key for key in client.smembers(self.app.conf.REDBEAT_STATICS_KEY))
         removed = previous.difference(self.app.conf.CELERYBEAT_SCHEDULE.keys())
+
         for name in removed:
             logger.debug("Removing old static schedule entry '%s'.", name)
             with client.pipeline() as pipe:

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -191,11 +191,11 @@ class RedBeatScheduler(Scheduler):
     def setup_schedule(self):
         # cleanup old static entries
         client = redis(self.app)
-        previous = client.smembers(self.app.conf.REDBEAT_STATICS_KEY)
-        current = set(self.app.conf.CELERYBEAT_SCHEDULE.keys())
-        removed = previous - current
+        previous = set(key.decode('utf-8')
+                       for key in client.smembers(self.app.conf.REDBEAT_STATICS_KEY))
+        removed = previous.difference(self.app.conf.CELERYBEAT_SCHEDULE.keys())
         for name in removed:
-            RedBeatSchedulerEntry(name).delete()
+            RedBeatSchedulerEntry(name, app=self.app).delete()
 
         # setup statics
         self.install_default_entries(self.app.conf.CELERYBEAT_SCHEDULE)

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -189,25 +189,27 @@ class RedBeatScheduler(Scheduler):
         super(RedBeatScheduler, self).__init__(app, **kwargs)
 
     def setup_schedule(self):
-        # cleanup old static entries
+        # cleanup old static schedule entries
         client = redis(self.app)
         previous = set(key.decode('utf-8')
                        for key in client.smembers(self.app.conf.REDBEAT_STATICS_KEY))
         removed = previous.difference(self.app.conf.CELERYBEAT_SCHEDULE.keys())
         for name in removed:
-            logger.debug("Removing old schedule entry '%s'.", name)
-            RedBeatSchedulerEntry(name, app=self.app).delete()
-            client.srem(self.app.conf.REDBEAT_STATICS_KEY, name)
+            logger.debug("Removing old static schedule entry '%s'.", name)
+            with client.pipeline() as pipe:
+                RedBeatSchedulerEntry(name, app=self.app).delete()
+                pipe.srem(self.app.conf.REDBEAT_STATICS_KEY, name)
+                pipe.execute()
 
-        # setup statics
+        # setup static schedule entries
         self.install_default_entries(self.app.conf.CELERYBEAT_SCHEDULE)
-        if not self.app.conf.CELERYBEAT_SCHEDULE:
-            return
+        if self.app.conf.CELERYBEAT_SCHEDULE:
+            self.update_from_dict(self.app.conf.CELERYBEAT_SCHEDULE)
 
-        self.update_from_dict(self.app.conf.CELERYBEAT_SCHEDULE)
-
-        # track static entries
-        client.sadd(self.app.conf.REDBEAT_STATICS_KEY, *self.app.conf.CELERYBEAT_SCHEDULE.keys())
+            # keep track of static schedule entries,
+            # so we notice when any are removed at next startup
+            client.sadd(self.app.conf.REDBEAT_STATICS_KEY,
+                        *self.app.conf.CELERYBEAT_SCHEDULE.keys())
 
     def update_from_dict(self, dict_):
         for name, entry in dict_.items():

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 celery
-fakeredis
+fakeredis>=0.8.1
 mock
 nose
 pytest

--- a/tests/basecase.py
+++ b/tests/basecase.py
@@ -14,7 +14,7 @@ class RedBeatCase(AppCase):
         })
         add_defaults(self.app)
 
-        self.app.redbeat_redis = FakeStrictRedis()
+        self.app.redbeat_redis = FakeStrictRedis(decode_responses=True)
         self.app.redbeat_redis.flushdb()
 
     def create_entry(self, name=None, task=None, s=None, run_every=60, **kwargs):

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -23,10 +23,10 @@ class test_RedBeatEntry(RedBeatCase):
             'options': {},
             'enabled': True,
         }
-        expected_key = (self.app.conf.REDBEAT_KEY_PREFIX + 'test').encode('utf-8')
+        expected_key = (self.app.conf.REDBEAT_KEY_PREFIX + 'test')
 
         redis = self.app.redbeat_redis
-        value = redis.hget(expected_key, 'definition').decode('utf8')
+        value = redis.hget(expected_key, 'definition')
         self.assertEqual(expected, json.loads(value, cls=RedBeatJSONDecoder))
         self.assertEqual(redis.zrank(self.app.conf.REDBEAT_SCHEDULE_KEY, e.key), 0)
         self.assertEqual(redis.zscore(self.app.conf.REDBEAT_SCHEDULE_KEY, e.key), e.score)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -65,10 +65,10 @@ class test_RedBeatScheduler(RedBeatCase):
         redis = self.app.redbeat_redis
 
         self.assertIn('test', s.schedule)
-        self.assertIn(b'test', redis.smembers(conf.REDBEAT_STATICS_KEY))
+        self.assertIn('test', redis.smembers(conf.REDBEAT_STATICS_KEY))
 
         conf.CELERYBEAT_SCHEDULE = {}
         s.setup_schedule()
 
         self.assertNotIn('test', s.schedule)
-        self.assertNotIn(b'test', redis.smembers(conf.REDBEAT_STATICS_KEY))
+        self.assertNotIn('test', redis.smembers(conf.REDBEAT_STATICS_KEY))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -52,3 +52,23 @@ class test_RedBeatScheduler(RedBeatCase):
 
         self.assertNotIn(up_next2.name, schedule)
         self.assertNotIn(way_out.name, schedule)
+
+    def test_old_static_entries_are_removed(self):
+        conf = self.app.conf
+        conf.CELERYBEAT_SCHEDULE = {
+            'test': {
+                'task': 'test',
+                'schedule': mocked_schedule(42)
+            }
+        }
+        s = self.create_scheduler()
+        redis = self.app.redbeat_redis
+
+        self.assertIn('test', s.schedule)
+        self.assertIn(b'test', redis.smembers(conf.REDBEAT_STATICS_KEY))
+
+        conf.CELERYBEAT_SCHEDULE = {}
+        s.setup_schedule()
+
+        self.assertNotIn('test', s.schedule)
+        self.assertNotIn(b'test', redis.smembers(conf.REDBEAT_STATICS_KEY))


### PR DESCRIPTION
* Decode static schedule entries keys returned as bytes from Redis.
* Pass app instance to `RedBeatSchedulerEntry`.

```
celery beat v3.1.23 (Cipater) is starting.
__    -    ... __   -        _
Configuration ->
    . broker -> redis://127.0.0.1:6379/1
    . loader -> celery.loaders.app.AppLoader
    . scheduler -> redbeat.schedulers.RedBeatScheduler
       . redis -> redis://127.0.0.1:6379/1
       . lock -> `redbeat::lock` 25.00 seconds (25s)
    . logfile -> [stderr]@%DEBUG
    . maxinterval -> 10.00 seconds (10.0s)
[2016-08-09 19:31:16,576: DEBUG/MainProcess] Setting default socket timeout to 30
[2016-08-09 19:31:16,577: INFO/MainProcess] beat: Starting...
[2016-08-09 19:31:16,581: CRITICAL/MainProcess] beat raised exception <class 'AttributeError'>: AttributeError("'NoneType' object has no attribute 'now'",)
Traceback (most recent call last):
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/kombu/utils/__init__.py", line 323, in __get__
    return obj.__dict__[self.__name__]
KeyError: 'scheduler'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/celery/apps/beat.py", line 112, in start_scheduler
    beat.start()
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/celery/beat.py", line 470, in start
    humanize_seconds(self.scheduler.max_interval))
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/kombu/utils/__init__.py", line 325, in __get__
    value = obj.__dict__[self.__name__] = self.__get(obj)
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/celery/beat.py", line 512, in scheduler
    return self.get_scheduler()
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/celery/beat.py", line 507, in get_scheduler
    lazy=lazy)
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/celery/utils/imports.py", line 53, in instantiate
    return symbol_by_name(name)(*args, **kwargs)
  File "/home/chris/work/celery/redbeat/redbeat/schedulers.py", line 190, in __init__
    super(RedBeatScheduler, self).__init__(app, **kwargs)
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/celery/beat.py", line 185, in __init__
    self.setup_schedule()
  File "/home/chris/work/celery/redbeat/redbeat/schedulers.py", line 199, in setup_schedule
    RedBeatSchedulerEntry(name).delete()
  File "/home/chris/work/celery/redbeat/redbeat/schedulers.py", line 71, in __init__
    args=args, kwargs=kwargs, **clsargs)
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/celery/beat.py", line 94, in __init__
    self.last_run_at = last_run_at or self._default_now()
  File "/home/chris/lib/virtualenvs/celery/lib/python3.5/site-packages/celery/beat.py", line 98, in _default_now
    return self.schedule.now() if self.schedule else self.app.now()
AttributeError: 'NoneType' object has no attribute 'now'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/34)
<!-- Reviewable:end -->
