### PR TITLE
Set 'decode_responses' on Redis client to True to ensure Python 3 comatiblity

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 celery
-fakeredis
+fakeredis>=0.8.1
 mock
 nose
 pytest

--- a/tests/basecase.py
+++ b/tests/basecase.py
@@ -14,7 +14,7 @@ class RedBeatCase(AppCase):
         })
         add_defaults(self.app)
 
-        self.app.redbeat_redis = FakeStrictRedis()
+        self.app.redbeat_redis = FakeStrictRedis(decode_responses=True)
         self.app.redbeat_redis.flushdb()
 
     def create_entry(self, name=None, task=None, s=None, run_every=60, **kwargs):

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -23,10 +23,10 @@ class test_RedBeatEntry(RedBeatCase):
             'options': {},
             'enabled': True,
         }
-        expected_key = (self.app.conf.REDBEAT_KEY_PREFIX + 'test').encode('utf-8')
+        expected_key = (self.app.conf.REDBEAT_KEY_PREFIX + 'test')
 
         redis = self.app.redbeat_redis
-        value = redis.hget(expected_key, 'definition').decode('utf8')
+        value = redis.hget(expected_key, 'definition')
         self.assertEqual(expected, json.loads(value, cls=RedBeatJSONDecoder))
         self.assertEqual(redis.zrank(self.app.conf.REDBEAT_SCHEDULE_KEY, e.key), 0)
         self.assertEqual(redis.zscore(self.app.conf.REDBEAT_SCHEDULE_KEY, e.key), e.score)


### PR DESCRIPTION
This reverts some changes from #33 in favour of setting `decode_responses` to `True` on the Redis client instance.

This is now possible, because `fakeredis`, which is used for the tests, also supports `decode_responses` since version 0.8.x.

Signed-off-by: Christopher Arndt <christopher.arndt@rheinwerk-verlag.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/39)
<!-- Reviewable:end -->
