### PR TITLE
Fix task loading

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -18,11 +18,12 @@ from celery.utils.log import get_logger
 from celery.signals import beat_init
 try:  # celery 3.x
     from celery.utils.timeutils import humanize_seconds
+    from kombu.utils import cached_property
 except ImportError:  # celery 4.x
     from celery.utils.time import humanize_seconds
+    from kombu.utils.objects import cached_property
 from celery.app import app_or_default
 from celery.five import values
-from kombu.utils.objects import cached_property
 
 from redis.client import StrictRedis
 

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -99,7 +99,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
     @staticmethod
     def decode_meta(meta, app=None):
         if not meta:
-            return {'last_run_at': datetime.min}
+            return {'last_run_at': None}
 
         return json.loads(meta, cls=RedBeatJSONDecoder)
 
@@ -116,6 +116,10 @@ class RedBeatSchedulerEntry(ScheduleEntry):
         definition = RedBeatSchedulerEntry.decode_definition(definition)
         meta = RedBeatSchedulerEntry.decode_meta(meta)
         definition.update(meta)
+
+        entry = RedBeatSchedulerEntry(app=app, **definition)
+        # celery.ScheduleEntry sets last_run_at = utcnow(), which is confusing and wrong
+        entry.last_run_at = meta['last_run_at']
 
         return entry
 

--- a/tests/basecase.py
+++ b/tests/basecase.py
@@ -1,5 +1,17 @@
-from celery.tests.case import AppCase
+
 from celery.schedules import schedule
+
+
+try:  # celery 3.x
+    from celery.tests.case import AppCase
+except ImportError:  # celery 4.x
+    from unittest import TestCase
+    from celery.contrib.testing.app import TestApp
+
+    class AppCase(TestCase):
+        def setUp(self):
+            self.app = TestApp()
+            self.setup()
 
 from fakeredis import FakeStrictRedis
 from redbeat import RedBeatSchedulerEntry

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -115,20 +115,21 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
 
     def test_old_static_entries_are_removed(self):
         conf = self.app.conf
+        redis = self.app.redbeat_redis
+
         conf.CELERYBEAT_SCHEDULE = {
             'test': {
                 'task': 'test',
                 'schedule': mocked_schedule(42)
             }
         }
-        s = self.create_scheduler()
-        redis = self.app.redbeat_redis
+        self.s.setup_schedule()
 
-        self.assertIn('test', s.schedule)
+        self.assertIn('test', self.s.schedule)
         self.assertIn('test', redis.smembers(conf.REDBEAT_STATICS_KEY))
 
         conf.CELERYBEAT_SCHEDULE = {}
-        s.setup_schedule()
+        self.s.setup_schedule()
 
-        self.assertNotIn('test', s.schedule)
+        self.assertNotIn('test', self.s.schedule)
         self.assertNotIn('test', redis.smembers(conf.REDBEAT_STATICS_KEY))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta
 from celery.schedules import schedule
 from celery.utils.timeutils import maybe_timedelta
 
+from mock import patch, ANY
+
 from basecase import RedBeatCase
 from redbeat import RedBeatScheduler
 
@@ -19,29 +21,34 @@ class mocked_schedule(schedule):
 
 
 due_now = mocked_schedule(0)
+due_next = mocked_schedule(1)
 
 
-class test_RedBeatScheduler(RedBeatCase):
+class RedBeatSchedulerTestBase(RedBeatCase):
+    def setUp(self):
+        super(RedBeatSchedulerTestBase, self).setUp()
+        self.s = RedBeatScheduler(app=self.app)
+        self.due_later = mocked_schedule(self.s.max_interval * 10)
+        self.send_task = patch.object(self.s, 'send_task')
+        self.send_task.start()
 
-    def create_scheduler(self):
-        return RedBeatScheduler(app=self.app)
+    def tearDown(self):
+        self.send_task.stop()
+
+
+class test_RedBeatScheduler_schedule(RedBeatSchedulerTestBase):
 
     def test_empty_schedule(self):
-        s = self.create_scheduler()
-
-        self.assertEqual(s.schedule, {})
-        sleep = s.tick()
-        self.assertEqual(sleep, s.max_interval)
+        self.assertEqual(self.s.schedule, {})
 
     def test_schedule_includes_current_and_next(self):
-        s = self.create_scheduler()
-
         due = self.create_entry(name='due', s=due_now).save()
-        up_next = self.create_entry(name='up_next', s=mocked_schedule(1)).save()
-        up_next2 = self.create_entry(name='up_next2', s=mocked_schedule(1)).save()
-        way_out = self.create_entry(name='way_out', s=mocked_schedule(s.max_interval * 10)).save()
+        up_next = self.create_entry(name='up_next', s=due_next).save()
+        up_next2 = self.create_entry(name='up_next2', s=due_next).save()
+        later = self.create_entry(name='later', s=self.due_later).save()
 
-        schedule = s.schedule
+        schedule = self.s.schedule
+
         self.assertEqual(len(schedule), 2)
 
         self.assertIn(due.name, schedule)
@@ -51,4 +58,53 @@ class test_RedBeatScheduler(RedBeatCase):
         self.assertEqual(up_next.key, schedule[up_next.name].key)
 
         self.assertNotIn(up_next2.name, schedule)
-        self.assertNotIn(way_out.name, schedule)
+        self.assertNotIn(later.name, schedule)
+
+
+class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
+
+    def test_empty(self):
+        with patch.object(self.s, 'send_task') as send_task:
+            sleep = self.s.tick()
+            self.assertFalse(send_task.called)
+
+        self.assertEqual(sleep, self.s.max_interval)
+
+    def test_due_next_never_run(self):
+        e = self.create_entry(name='next', s=due_next).save()
+
+        with patch.object(self.s, 'send_task') as send_task:
+            sleep = self.s.tick()
+            # debateable if we should be calling the task that isn't due quite yet
+            #self.assertFalse(send_task.called)
+            send_task.assert_called_with(e.task, e.args, e.kwargs, publisher=ANY, **e.options)
+
+        self.assertEqual(sleep, 1.0)
+
+    def test_due_next_just_ran(self):
+        e = self.create_entry(name='next', s=due_next)
+        e.save().reschedule()
+
+        with patch.object(self.s, 'send_task') as send_task:
+            sleep = self.s.tick()
+            self.assertFalse(send_task.called)
+        self.assertLess(0.8, sleep)
+        self.assertLess(sleep, 1.0)
+
+    def test_due_later_never_run(self):
+        self.create_entry(s=self.due_later).save()
+
+        with patch.object(self.s, 'send_task') as send_task:
+            sleep = self.s.tick()
+            self.assertFalse(send_task.called)
+
+        self.assertEqual(sleep, self.s.max_interval)
+
+    def test_due_now_never_run(self):
+        e = self.create_entry(name='now', s=due_now).save()
+
+        with patch.object(self.s, 'send_task') as send_task:
+            sleep = self.s.tick()
+            send_task.assert_called_with(e.task, e.args, e.kwargs, publisher=ANY, **e.options)
+
+        self.assertEqual(sleep, 1.0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27}-celery{3}
+envlist=py{27}-celery{3,4}
 
 [testenv]
 deps= 


### PR DESCRIPTION
while adding tests to cover #42, I found an error with task loading and in the course of testing I found additional issues with celery 4.x.  This now introduces a number of changes at once :( but its somewhat hard to detangle them as the test changes are required to expose the bug.

 - copy tick() and maybe_due() from celery 3.x
 - fix renames between celery 3.x and 4.x, imports and publisher/producer
 - add more tests
 - fix bug in loading newly created entries that don't have any metadata defined yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/43)
<!-- Reviewable:end -->
