### PR TITLE
start using tox to test celery 3 vs 4, refs #44

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist=py{27}-celery{3}
+
+[testenv]
+deps= 
+    celery3: celery<4.0
+    celery4: celery>=4.0
+    fakeredis
+    mock
+    celery3: nose
+    redis
+    pytest
+    pytest-catchlog
+
+commands=py.test


### PR DESCRIPTION
not testing with celery 4 yet as it would break CI.