### PR TITLE
Improve Celery 3 and 4 configuration compatibility.

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -5,15 +5,18 @@
 
 from __future__ import absolute_import
 
-from datetime import datetime, MINYEAR
 import time
+import warnings
+from datetime import datetime, MINYEAR
+from distutils.version import StrictVersion
 
 try:
     import simplejson as json
 except ImportError:
     import json
 
-from celery.beat import Scheduler, ScheduleEntry
+from celery import __version__ as celery_version
+from celery.beat import Scheduler, ScheduleEntry, DEFAULT_MAX_INTERVAL
 from celery.utils.log import get_logger
 from celery.signals import beat_init
 try:  # celery 3.x
@@ -29,25 +32,14 @@ from redis.client import StrictRedis
 
 from .decoder import RedBeatJSONEncoder, RedBeatJSONDecoder
 
-
-def add_defaults(app=None):
-    app = app_or_default(app)
-
-    app.add_defaults({
-        'REDBEAT_REDIS_URL': app.conf.get('REDBEAT_REDIS_URL', app.conf['BROKER_URL']),
-        'REDBEAT_KEY_PREFIX': app.conf.get('REDBEAT_KEY_PREFIX', 'redbeat:'),
-        'REDBEAT_SCHEDULE_KEY': app.conf.get('REDBEAT_KEY_PREFIX', 'redbeat:') + ':schedule',
-        'REDBEAT_STATICS_KEY': app.conf.get('REDBEAT_KEY_PREFIX', 'redbeat:') + ':statics',
-        'REDBEAT_LOCK_KEY': app.conf.get('REDBEAT_KEY_PREFIX', 'redbeat:') + ':lock',
-        'REDBEAT_LOCK_TIMEOUT': app.conf.CELERYBEAT_MAX_LOOP_INTERVAL * 5,
-    })
+CELERY_4_OR_GREATER = StrictVersion(celery_version) >= StrictVersion('4.0')
 
 
 def redis(app=None):
     app = app_or_default(app)
-
+    conf = getattr(app, 'redbeat_conf', RedBeatConfig(app))
     if not hasattr(app, 'redbeat_redis') or app.redbeat_redis is None:
-        app.redbeat_redis = StrictRedis.from_url(app.conf.REDBEAT_REDIS_URL,
+        app.redbeat_redis = StrictRedis.from_url(conf.redis_url,
                                                  decode_responses=True)
 
     return app.redbeat_redis
@@ -69,10 +61,54 @@ def from_timestamp(ts):
     return datetime.fromtimestamp(ts)
 
 
+class RedBeatConfig(object):
+    if CELERY_4_OR_GREATER:
+        max_loop_interval_config = 'beat_max_loop_interval'
+    else:
+        max_loop_interval_config = 'CELERYBEAT_MAX_LOOP_INTERVAL'
+
+    def __init__(self, app=None):
+        self.app = app_or_default(app)
+        self.key_prefix = self.either_or('redbeat_key_prefix', 'redbeat:')
+        self.schedule_key = self.key_prefix + ':schedule'
+        self.statics_key = self.key_prefix + ':statics'
+        self.lock_key = self.key_prefix + ':lock'
+        self.lock_timeout = self.either_or('redbeat_lock_timeout', self.max_loop_interval * 5)
+        self.redis_url = self.either_or('redbeat_redis_url', app.conf['BROKER_URL'])
+
+    @property
+    def max_loop_interval(self):
+        return self.app.conf.get(self.max_loop_interval_config, DEFAULT_MAX_INTERVAL)
+
+    @property
+    def schedule(self):
+        if CELERY_4_OR_GREATER:
+            return self.app.conf.beat_schedule
+        else:
+            return self.app.conf.CELERYBEAT_SCHEDULE
+
+    @schedule.setter
+    def schedule(self, value):
+        if CELERY_4_OR_GREATER:
+            self.app.conf.beat_schedule = value
+        else:
+            self.app.conf.CELERYBEAT_SCHEDULE = value
+
+    def either_or(self, name, default=None):
+        if CELERY_4_OR_GREATER and name == name.upper():
+            warnings.warn(
+                'Celery v4 installed, but detected Celery v3 '
+                'configuration %s (use %s instead).' % (name, name.lower()),
+                UserWarning
+            )
+        return self.app.conf.first(name, name.upper()) or default
+
+
 class RedBeatSchedulerEntry(ScheduleEntry):
     _meta = None
 
-    def __init__(self, name=None, task=None, schedule=None, args=None, kwargs=None, enabled=True, **clsargs):
+    def __init__(self, name=None, task=None, schedule=None,
+                 args=None, kwargs=None, enabled=True, **clsargs):
         super(RedBeatSchedulerEntry, self).__init__(name=name, task=task, schedule=schedule,
                                                     args=args, kwargs=kwargs, **clsargs)
         self.enabled = enabled
@@ -140,7 +176,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
 
     @property
     def key(self):
-        return app_or_default(self.app).conf['REDBEAT_KEY_PREFIX'] + self.name
+        return self.app.redbeat_conf.key_prefix + self.name
 
     @property
     def score(self):
@@ -148,7 +184,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
 
     @property
     def rank(self):
-        return redis(self.app).zrank(self.app.conf.REDBEAT_SCHEDULE_KEY, self.key)
+        return redis(self.app).zrank(self.app.redbeat_conf.schedule_key, self.key)
 
     def save(self):
         definition = {
@@ -162,14 +198,14 @@ class RedBeatSchedulerEntry(ScheduleEntry):
         }
         with redis(self.app).pipeline() as pipe:
             pipe.hset(self.key, 'definition', json.dumps(definition, cls=RedBeatJSONEncoder))
-            pipe.zadd(self.app.conf.REDBEAT_SCHEDULE_KEY, self.score, self.key)
+            pipe.zadd(self.app.redbeat_conf.schedule_key, self.score, self.key)
             pipe.execute()
 
         return self
 
     def delete(self):
         with redis(self.app).pipeline() as pipe:
-            pipe.zrem(self.app.conf.REDBEAT_SCHEDULE_KEY, self.key)
+            pipe.zrem(self.app.redbeat_conf.schedule_key, self.key)
             pipe.delete(self.key)
             pipe.execute()
 
@@ -187,7 +223,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
 
         with redis(self.app).pipeline() as pipe:
             pipe.hset(self.key, 'meta', json.dumps(meta, cls=RedBeatJSONEncoder))
-            pipe.zadd(self.app.conf.REDBEAT_SCHEDULE_KEY, entry.score, entry.key)
+            pipe.zadd(self.app.redbeat_conf.schedule_key, entry.score, entry.key)
             pipe.execute()
 
         return entry
@@ -200,7 +236,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
         }
         with redis(self.app).pipeline() as pipe:
             pipe.hset(self.key, 'meta', json.dumps(meta, cls=RedBeatJSONEncoder))
-            pipe.zadd(self.app.conf.REDBEAT_SCHEDULE_KEY, self.score, self.key)
+            pipe.zadd(self.app.redbeat_conf.schedule_key, self.score, self.key)
             pipe.execute()
 
     def is_due(self):
@@ -219,33 +255,33 @@ class RedBeatScheduler(Scheduler):
     lock = None
 
     def __init__(self, app, **kwargs):
-        add_defaults(app)
-        self.lock_key = kwargs.pop('lock_key', app.conf.REDBEAT_LOCK_KEY)
-        self.lock_timeout = kwargs.pop('lock_timeout', app.conf.REDBEAT_LOCK_TIMEOUT)
+        app.redbeat_conf = RedBeatConfig(app)
+        self.lock_key = kwargs.pop('lock_key', app.redbeat_conf.lock_key)
+        self.lock_timeout = kwargs.pop('lock_timeout', app.redbeat_conf.lock_timeout)
         super(RedBeatScheduler, self).__init__(app, **kwargs)
 
     def setup_schedule(self):
         # cleanup old static schedule entries
         client = redis(self.app)
-        previous = set(key for key in client.smembers(self.app.conf.REDBEAT_STATICS_KEY))
-        removed = previous.difference(self.app.conf.CELERYBEAT_SCHEDULE.keys())
+        previous = set(key for key in client.smembers(self.app.redbeat_conf.statics_key))
+        removed = previous.difference(self.app.redbeat_conf.schedule.keys())
 
         for name in removed:
             logger.debug("Removing old static schedule entry '%s'.", name)
             with client.pipeline() as pipe:
                 RedBeatSchedulerEntry(name, app=self.app).delete()
-                pipe.srem(self.app.conf.REDBEAT_STATICS_KEY, name)
+                pipe.srem(self.app.redbeat_conf.statics_key, name)
                 pipe.execute()
 
         # setup static schedule entries
-        self.install_default_entries(self.app.conf.CELERYBEAT_SCHEDULE)
-        if self.app.conf.CELERYBEAT_SCHEDULE:
-            self.update_from_dict(self.app.conf.CELERYBEAT_SCHEDULE)
+        self.install_default_entries(self.app.redbeat_conf.schedule)
+        if self.app.redbeat_conf.schedule:
+            self.update_from_dict(self.app.redbeat_conf.schedule)
 
             # keep track of static schedule entries,
             # so we notice when any are removed at next startup
-            client.sadd(self.app.conf.REDBEAT_STATICS_KEY,
-                        *self.app.conf.CELERYBEAT_SCHEDULE.keys())
+            client.sadd(self.app.redbeat_conf.statics_key,
+                        *self.app.redbeat_conf.schedule.keys())
 
     def update_from_dict(self, dict_):
         for name, entry in dict_.items():
@@ -270,10 +306,10 @@ class RedBeatScheduler(Scheduler):
         client = redis(self.app)
 
         with client.pipeline() as pipe:
-            pipe.zrangebyscore(self.app.conf.REDBEAT_SCHEDULE_KEY, 0, max_due_at)
+            pipe.zrangebyscore(self.app.redbeat_conf.schedule_key, 0, max_due_at)
 
             # peek into the next tick to accuratly calculate sleep between ticks
-            pipe.zrangebyscore(self.app.conf.REDBEAT_SCHEDULE_KEY,
+            pipe.zrangebyscore(self.app.redbeat_conf.schedule_key,
                                '({}'.format(max_due_at),
                                max_due_at + self.max_interval,
                                start=0, num=1)
@@ -286,7 +322,7 @@ class RedBeatScheduler(Scheduler):
                 entry = self.Entry.from_key(key, app=self.app)
             except KeyError:
                 logger.warning('failed to load %s, removing', key)
-                client.zrem(self.app.conf.REDBEAT_SCHEDULE_KEY, key)
+                client.zrem(self.app.redbeat_conf.schedule_key, key)
                 continue
 
             d[entry.name] = entry
@@ -331,7 +367,7 @@ class RedBeatScheduler(Scheduler):
 
     @property
     def info(self):
-        info = ['       . redis -> {}'.format(self.app.conf.REDBEAT_REDIS_URL)]
+        info = ['       . redis -> {}'.format(self.app.redbeat_conf.redis_url)]
         if self.lock_key:
             info.append('       . lock -> `{}` {} ({}s)'.format(
                 self.lock_key, humanize_seconds(self.lock_timeout), self.lock_timeout))
@@ -340,10 +376,11 @@ class RedBeatScheduler(Scheduler):
     @cached_property
     def _maybe_due_kwargs(self):
         """ handle rename of publisher to producer """
-        try:
+        if CELERY_4_OR_GREATER:
             return {'producer': self.producer}  # celery 4.x
-        except AttributeError:
+        else:
             return {'publisher': self.publisher}  # celery 3.x
+
 
 @beat_init.connect
 def acquire_distributed_beat_lock(sender=None, **kwargs):
@@ -354,6 +391,9 @@ def acquire_distributed_beat_lock(sender=None, **kwargs):
     logger.debug('beat: Acquiring lock...')
 
     lock = redis(scheduler.app).lock(
-            scheduler.lock_key, timeout=scheduler.lock_timeout, sleep=scheduler.max_interval)
+        scheduler.lock_key,
+        timeout=scheduler.lock_timeout,
+        sleep=scheduler.max_interval,
+    )
     lock.acquire()
     scheduler.lock = lock

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -83,7 +83,7 @@ class RedBeatConfig(object):
         self.key_prefix = self.either_or('redbeat_key_prefix', 'redbeat:')
         self.schedule_key = self.key_prefix + ':schedule'
         self.statics_key = self.key_prefix + ':statics'
-        self.lock_key = self.key_prefix + ':lock'
+        self.lock_key = self.either_or('redbeat_lock_key', self.key_prefix + ':lock')
         self.lock_timeout = self.either_or('redbeat_lock_timeout', None)
         self.redis_url = self.either_or('redbeat_redis_url', app.conf['BROKER_URL'])
 

--- a/tests/basecase.py
+++ b/tests/basecase.py
@@ -14,7 +14,7 @@ except ImportError:  # celery 4.x
             self.setup()
 
 from fakeredis import FakeStrictRedis
-from redbeat.schedulers import RedBeatConfig, RedBeatSchedulerEntry
+from redbeat.schedulers import RedBeatSchedulerEntry
 
 
 class RedBeatCase(AppCase):
@@ -26,7 +26,6 @@ class RedBeatCase(AppCase):
         })
         self.app.redbeat_redis = FakeStrictRedis(decode_responses=True)
         self.app.redbeat_redis.flushdb()
-        self.app.redbeat_conf = RedBeatConfig(self.app)
 
     def create_entry(self, name=None, task=None, s=None, run_every=60, **kwargs):
 

--- a/tests/basecase.py
+++ b/tests/basecase.py
@@ -14,8 +14,7 @@ except ImportError:  # celery 4.x
             self.setup()
 
 from fakeredis import FakeStrictRedis
-from redbeat import RedBeatSchedulerEntry
-from redbeat.schedulers import add_defaults
+from redbeat.schedulers import RedBeatConfig, RedBeatSchedulerEntry
 
 
 class RedBeatCase(AppCase):
@@ -23,11 +22,11 @@ class RedBeatCase(AppCase):
     def setup(self):
         self.app.conf.add_defaults({
             'REDBEAT_KEY_PREFIX': 'rb-tests:',
+            'redbeat_key_prefix': 'rb-tests:',
         })
-        add_defaults(self.app)
-
         self.app.redbeat_redis = FakeStrictRedis(decode_responses=True)
         self.app.redbeat_redis.flushdb()
+        self.app.redbeat_conf = RedBeatConfig(self.app)
 
     def create_entry(self, name=None, task=None, s=None, run_every=60, **kwargs):
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,13 +13,10 @@ class test_RedBeatConfig(AppCase):
     def test_app(self):
         self.assertEqual(self.app, self.conf.app)
 
-    def test_max_loop_interval(self):
-        self.app.conf[RedBeatConfig.max_loop_interval_config] = 12
-        self.conf = RedBeatConfig(self.app)
-        self.assertEqual(self.conf.max_loop_interval, 12)
-
     def test_lock_timeout(self):
-        self.assertEqual(self.conf.lock_timeout, self.conf.max_loop_interval * 5)
+        # the config only has the lock_timeout if it was overidden
+        # via the REDBEAT_LOCK_TIMEOUT, see test_scheduler.py for real test
+        self.assertEqual(self.conf.lock_timeout, None)
 
     def test_key_prefix_default(self):
         self.assertEqual(self.conf.key_prefix, 'redbeat:')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,61 @@
+import mock
+import pytest
+from redbeat.schedulers import RedBeatConfig, CELERY_4_OR_GREATER
+
+from basecase import AppCase
+
+
+class test_RedBeatConfig(AppCase):
+
+    def setup(self):
+        self.conf = RedBeatConfig(self.app)
+
+    def test_app(self):
+        self.assertEqual(self.app, self.conf.app)
+
+    def test_max_loop_interval(self):
+        self.app.conf[RedBeatConfig.max_loop_interval_config] = 12
+        self.conf = RedBeatConfig(self.app)
+        self.assertEqual(self.conf.max_loop_interval, 12)
+
+    def test_lock_timeout(self):
+        self.assertEqual(self.conf.lock_timeout, self.conf.max_loop_interval * 5)
+
+    def test_key_prefix_default(self):
+        self.assertEqual(self.conf.key_prefix, 'redbeat:')
+
+    def test_other_keys(self):
+        self.assertEqual(self.conf.schedule_key, self.conf.key_prefix + ':schedule')
+        self.assertEqual(self.conf.statics_key, self.conf.key_prefix + ':statics')
+        self.assertEqual(self.conf.lock_key, self.conf.key_prefix + ':lock')
+
+    @pytest.mark.skipif(not CELERY_4_OR_GREATER, reason="requires Celery >= 4.x")
+    def test_key_prefix_override_4(self):
+        self.app.conf.redbeat_key_prefix = 'test-prefix:'
+        self.conf = RedBeatConfig(self.app)
+        self.assertEqual(self.conf.key_prefix, 'test-prefix:')
+
+    @pytest.mark.skipif(CELERY_4_OR_GREATER, reason="requires Celery < 4.x")
+    def test_key_prefix_override_3(self):
+        self.app.conf.REDBEAT_KEY_PREFIX = 'test-prefix:'
+        self.conf = RedBeatConfig(self.app)
+        self.assertEqual(self.conf.key_prefix, 'test-prefix:')
+
+    def test_schedule(self):
+        schedule = {'foo': 'bar'}
+        self.conf.schedule = schedule
+        self.assertEqual(self.conf.schedule, schedule)
+
+    @pytest.mark.skipif(CELERY_4_OR_GREATER, reason="requires Celery < 4.x")
+    @mock.patch('warnings.warn')
+    def test_either_or_3(self, warn_mock):
+        broker_url = self.conf.either_or('BROKER_URL')
+        self.assertFalse(warn_mock.called)
+        self.assertEqual(broker_url, self.app.conf.BROKER_URL)
+
+    @pytest.mark.skipif(not CELERY_4_OR_GREATER, reason="requires Celery >= 4.x")
+    @mock.patch('warnings.warn')
+    def test_either_or_4(self, warn_mock):
+        broker_url = self.conf.either_or('BROKER_URL')
+        self.assertTrue(warn_mock.called)
+        self.assertEqual(broker_url, self.app.conf.broker_url)

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -23,13 +23,13 @@ class test_RedBeatEntry(RedBeatCase):
             'options': {},
             'enabled': True,
         }
-        expected_key = (self.app.conf.REDBEAT_KEY_PREFIX + 'test')
+        expected_key = (self.app.redbeat_conf.key_prefix + 'test')
 
         redis = self.app.redbeat_redis
         value = redis.hget(expected_key, 'definition')
         self.assertEqual(expected, json.loads(value, cls=RedBeatJSONDecoder))
-        self.assertEqual(redis.zrank(self.app.conf.REDBEAT_SCHEDULE_KEY, e.key), 0)
-        self.assertEqual(redis.zscore(self.app.conf.REDBEAT_SCHEDULE_KEY, e.key), e.score)
+        self.assertEqual(redis.zrank(self.app.redbeat_conf.schedule_key, e.key), 0)
+        self.assertEqual(redis.zscore(self.app.redbeat_conf.schedule_key, e.key), e.score)
 
     def test_from_key_nonexistent_key(self):
         with self.assertRaises(KeyError):
@@ -60,7 +60,7 @@ class test_RedBeatEntry(RedBeatCase):
 
         # new entry updated the schedule
         redis = self.app.redbeat_redis
-        self.assertEqual(redis.zscore(self.app.conf.REDBEAT_SCHEDULE_KEY, n.key), n.score)
+        self.assertEqual(redis.zscore(self.app.redbeat_conf.schedule_key, n.key), n.score)
 
     def test_next_only_update_last_run_at(self):
         initial = self.create_entry()
@@ -79,7 +79,7 @@ class test_RedBeatEntry(RedBeatCase):
         exists = self.app.redbeat_redis.exists(initial.key)
         self.assertFalse(exists)
 
-        score = self.app.redbeat_redis.zrank(self.app.conf.REDBEAT_SCHEDULE_KEY, initial.key)
+        score = self.app.redbeat_redis.zrank(self.app.redbeat_conf.schedule_key, initial.key)
         self.assertIsNone(score)
 
     def test_due_at_never_run(self):
@@ -114,7 +114,7 @@ class test_RedBeatEntry(RedBeatCase):
         self.assertGreater(due_at, before)
 
     def test_score(self):
-        run_every = 61*60
+        run_every = 61 * 60
         entry = self.create_entry(run_every=run_every)
         entry = entry._next_instance()
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -132,3 +132,6 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
 
         self.assertNotIn('test', self.s.schedule)
         self.assertNotIn('test', redis.smembers(self.app.redbeat_conf.statics_key))
+
+    def test_lock_timeout(self):
+        self.assertEqual(self.s.lock_timeout, self.s.max_interval * 5)


### PR DESCRIPTION
This introduces a separate RedBeatConfig class and stops using
Celery’s config system to better support both Celery 3 and 4 at
the same time despite its differences in config handling.

This also fixes issue #50.

This also makes sure the config variables are loaded
when using the redis helper function which could previously
lead to race conditions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/51)
<!-- Reviewable:end -->
