### PR TITLE
(fix) pass lock_timeout from app config if present

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -270,6 +270,7 @@ class RedBeatScheduler(Scheduler):
         ensure_conf(app)  # set app.redbeat_conf
         self.lock_key = lock_key or app.redbeat_conf.lock_key
         self.lock_timeout = (lock_timeout or
+                             app.redbeat_conf.lock_timeout or
                              self.max_interval * 5 or
                              self.lock_timeout)
         super(RedBeatScheduler, self).__init__(app, **kwargs)


### PR DESCRIPTION
Resolves https://github.com/sibson/redbeat/issues/58

**Testing**
Added to `exampleconf.py`:
```
REDBEAT_LOCK_TIMEOUT = 15
```

Result of running `PYTHONPATH=. celery beat --config exampleconf`:
```
(.venv) Arics-MacBook-Pro:redbeat aric$ PYTHONPATH=. celery beat --config exampleconf
celery beat v4.0.2 (latentcall) is starting.
__    -    ... __   -        _
LocalTime -> 2017-06-16 12:12:18
Configuration ->
    . broker -> redis://localhost:6379//
    . loader -> celery.loaders.default.Loader
    . scheduler -> redbeat.schedulers.RedBeatScheduler
       . redis -> redis://
       . lock -> `redbeat::lock` 15.00 seconds (15s)
    . logfile -> [stderr]@%WARNING
    . maxinterval -> 5.00 seconds (5s)
```

Checked `redbeat::lock` key in Redis, confirmed that TTL is 15s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/59)
<!-- Reviewable:end -->
