### PR TITLE
Recurrence rule support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# VirtualEnv
+.venv
+

--- a/redbeat/decoder.py
+++ b/redbeat/decoder.py
@@ -32,12 +32,11 @@ class RedBeatJSONDecoder(json.JSONDecoder):
             return crontab(**d)
 
         if objtype == 'rrule':
-            rrule_dict = d
             # Decode timestamp values into datetime objects
             for key in ['dtstart', 'until']:
-                if rrule_dict[key] is not None:
-                    rrule_dict[key] = datetime.fromtimestamp(rrule_dict[key])
-            return rrule(**rrule_dict)
+                if d[key] is not None:
+                    d[key] = datetime.fromtimestamp(d[key])
+            return rrule(**d)
 
         d['__type__'] = objtype
 

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -258,7 +258,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
             return False, 5.0  # 5 second delay for re-enable.
 
         return self.schedule.is_due(self.last_run_at or
-                                    datetime(MINYEAR, 1, 1, tzinfo=self.schedule.tz))
+                                    datetime(MINYEAR, 1, 1))
 
 
 class RedBeatScheduler(Scheduler):

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -339,7 +339,7 @@ class RedBeatScheduler(Scheduler):
         d = {}
         for key, score in due_tasks + maybe_due:
             if score < 0:
-                logger.info('removing ended schedule %s', key)
+                logger.info('Scheduler: Removing ended schedule %s', key)
                 client.zrem(self.app.redbeat_conf.schedule_key, key)
                 continue
             try:

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -258,7 +258,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
             return False, 5.0  # 5 second delay for re-enable.
 
         return self.schedule.is_due(self.last_run_at or
-                                    datetime(MINYEAR, 1, 1))
+                                    datetime(MINYEAR, 1, 1, tzinfo=self.schedule.tz))
 
 
 class RedBeatScheduler(Scheduler):

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -177,7 +177,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
 
         delta = self.schedule.remaining_estimate(self.last_run_at)
         # if no delta, means no more events after the last_run_at.
-        if not delta:
+        if delta is None:
             return None
 
         # overdue => due now
@@ -192,7 +192,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
 
     @property
     def score(self):
-        if not self.due_at:
+        if self.due_at is None:
             return -1
         return to_timestamp(self.due_at)
 
@@ -332,7 +332,7 @@ class RedBeatScheduler(Scheduler):
             pipe.zrangebyscore(self.app.redbeat_conf.schedule_key,
                                '({}'.format(max_due_at),
                                max_due_at + self.max_interval,
-                               start=-1, num=1, withscores=True)
+                               start=0, num=1, withscores=True)
             due_tasks, maybe_due = pipe.execute()
 
         logger.info('Loading %d tasks', len(due_tasks) + len(maybe_due))

--- a/redbeat/schedules.py
+++ b/redbeat/schedules.py
@@ -40,10 +40,15 @@ class rrule(schedule):
                  byweekno=None, byweekday=None,
                  byhour=None, byminute=None, bysecond=None,
                  **kwargs):
+        super(rrule, self).__init__(**kwargs)
+
         if type(freq) == str:
             freq_str = freq.upper()
             assert freq_str in rrule.FREQ_MAP
             freq = rrule.FREQ_MAP[freq_str]
+
+        dtstart = self.maybe_make_aware(dtstart) if dtstart else None
+        until = self.maybe_make_aware(until) if until else None
 
         self.freq = freq
         self.dtstart = dtstart
@@ -64,14 +69,14 @@ class rrule(schedule):
         self.rrule = dateutil_rrule(freq, dtstart, interval, wkst, count, until,
                                     bysetpos, bymonth, bymonthday, byyearday, byeaster,
                                     byweekno, byweekday, byhour, byminute, bysecond)
-        super(rrule, self).__init__(**kwargs)
 
     def remaining_estimate(self, last_run_at):
-        # This expects last_run_at to be in UTC time.
-        next_run_utc = self.rrule.after(last_run_at)
-        if next_run_utc:
-            now_utc = self.now()
-            delta = next_run_utc - now_utc
+        last_run_at = self.maybe_make_aware(last_run_at)
+        next_run = self.rrule.after(last_run_at)
+        if next_run:
+            next_run = self.maybe_make_aware(next_run)
+            now = self.maybe_make_aware(self.now())
+            delta = next_run - now
             return delta
         return None
 

--- a/redbeat/schedules.py
+++ b/redbeat/schedules.py
@@ -1,0 +1,74 @@
+import celery
+from dateutil.rrule import rrule as dateutil_rrule
+from celery.schedules import BaseSchedule
+from celery.utils.time import (
+    localize,
+    timezone
+)
+
+
+class rrule(BaseSchedule):
+    RRULE_REPR = """\
+    <rrule: {0._freq} {0._interval}>\
+    """
+
+    def __init__(self, freq, dtstart=None,
+                 interval=1, wkst=None, count=None, until=None, bysetpos=None,
+                 bymonth=None, bymonthday=None, byyearday=None, byeaster=None,
+                 byweekno=None, byweekday=None,
+                 byhour=None, byminute=None, bysecond=None,
+                 **kwargs):
+        self.freq = freq
+        self.dtstart = dtstart
+        self.interval = interval
+        self.wkst = wkst
+        self.count = count
+        self.until = until
+        self.bysetpos = bysetpos
+        self.bymonth = bymonth
+        self.bymonthday = bymonthday
+        self.byyearday = byyearday
+        self.byeaster = byeaster
+        self.byweekno = byweekno
+        self.byweekday = byweekday
+        self.byhour = byhour
+        self.byminute = byminute
+        self.bysecond = bysecond
+        self.rrule = dateutil_rrule(freq, dtstart, interval, wkst, count, until,
+                                    bysetpos, bymonth, bymonthday, byyearday, byeaster,
+                                    byweekno, byweekday, byhour, byminute, bysecond)
+        super(rrule, self).__init__(**kwargs)
+
+    def remaining_estimate(self, last_run_at):
+        last_run_at = self.maybe_make_aware(last_run_at)
+        last_run_at_utc = localize(last_run_at, timezone.utc)
+        print last_run_at
+        print last_run_at_utc
+        last_run_at_utc_naive = last_run_at_utc.replace(tzinfo=None)
+        next_run_utc = self.rrule.after(last_run_at_utc_naive)
+        if next_run_utc:
+            next = self.maybe_make_aware(next_run_utc)
+            now = self.maybe_make_aware(self.now())
+            delta = next - now
+            return delta
+        return None
+
+    def is_due(self, last_run_at):
+        rem_delta = self.remaining_estimate(last_run_at)
+        if rem_delta:
+            rem = max(rem_delta.total_seconds(), 0)
+            due = rem == 0
+            if due:
+                rem_delta = self.remaining_estimate(self.now())
+                if rem_delta:
+                    rem = max(rem_delta.total_seconds(), 0)
+                else:
+                    rem = 0
+            return celery.schedules.schedstate(due, rem)
+        return celery.schedules.schedstate(False, None)
+
+    def __repr__(self):
+        return self.RRULE_REPR.format(self)
+
+    def __reduce__(self):
+        return (self.__class__, (self.rrule), None)

--- a/redbeat/schedules.py
+++ b/redbeat/schedules.py
@@ -42,8 +42,6 @@ class rrule(BaseSchedule):
     def remaining_estimate(self, last_run_at):
         last_run_at = self.maybe_make_aware(last_run_at)
         last_run_at_utc = localize(last_run_at, timezone.utc)
-        print last_run_at
-        print last_run_at_utc
         last_run_at_utc_naive = last_run_at_utc.replace(tzinfo=None)
         next_run_utc = self.rrule.after(last_run_at_utc_naive)
         if next_run_utc:

--- a/redbeat/schedules.py
+++ b/redbeat/schedules.py
@@ -2,22 +2,18 @@ import celery
 from dateutil.rrule import rrule as dateutil_rrule
 try:  # celery 4.x
     from celery.schedules import BaseSchedule as schedule
-    from celery.utils.time import (
-        localize,
-        timezone
-    )
 except ImportError:  # celery 3.x
     from celery.schedules import schedule
-    from celery.utils.timeutils import (
-        localize,
-        timezone
-    )
 
 
 class rrule(schedule):
-    RRULE_REPR = """\
-    <rrule: {0._freq} {0._interval}>\
-    """
+    RRULE_REPR = (
+        '<rrule: freq: {0.freq}, dtstart: {0.dtstart}, interval: {0.interval}, '
+        'wkst: {0.wkst}, count: {0.count}, until: {0.until}, bysetpos: {0.bysetpos}, '
+        'bymonth: {0.bymonth}, bymonthday: {0.bymonthday}, byyearday: {0.byyearday}, '
+        'byeaster: {0.byeaster}, byweekno: {0.byweekno}, byweekday: {0.byweekday}, '
+        'byhour: {0.byhour}, byminute: {0.byminute}, bysecond: {0.bysecond}>'
+    )
 
     def __init__(self, freq, dtstart=None,
                  interval=1, wkst=None, count=None, until=None, bysetpos=None,

--- a/redbeat/schedules.py
+++ b/redbeat/schedules.py
@@ -47,7 +47,8 @@ class rrule(schedule):
             assert freq_str in rrule.FREQ_MAP
             freq = rrule.FREQ_MAP[freq_str]
 
-        dtstart = self.maybe_make_aware(dtstart) if dtstart else None
+        dtstart = self.maybe_make_aware(dtstart) if dtstart else \
+            self.maybe_make_aware(self.now())
         until = self.maybe_make_aware(until) if until else None
 
         self.freq = freq

--- a/redbeat/schedules.py
+++ b/redbeat/schedules.py
@@ -68,11 +68,7 @@ class rrule(schedule):
 
     def remaining_estimate(self, last_run_at):
         # This expects last_run_at to be in UTC time.
-        # Set tzinfo to None because last_run_at has tzinfo set if there is no metadata,
-        # however naive UTC times are used everywhere else and cannot be compared against
-        # tz-aware datetimes.
-        last_run_at_utc = last_run_at.replace(tzinfo=None)
-        next_run_utc = self.rrule.after(last_run_at_utc)
+        next_run_utc = self.rrule.after(last_run_at)
         if next_run_utc:
             now_utc = self.now()
             delta = next_run_utc - now_utc

--- a/redbeat/schedules.py
+++ b/redbeat/schedules.py
@@ -47,14 +47,15 @@ class rrule(schedule):
         super(rrule, self).__init__(**kwargs)
 
     def remaining_estimate(self, last_run_at):
-        last_run_at = self.maybe_make_aware(last_run_at)
-        last_run_at_utc = localize(last_run_at, timezone.utc)
-        last_run_at_utc_naive = last_run_at_utc.replace(tzinfo=None)
-        next_run_utc = self.rrule.after(last_run_at_utc_naive)
+        # This expects last_run_at to be in UTC time.
+        # Set tzinfo to None because last_run_at has tzinfo set if there is no metadata,
+        # however naive UTC times are used everywhere else and cannot be compared against
+        # tz-aware datetimes.
+        last_run_at_utc = last_run_at.replace(tzinfo=None)
+        next_run_utc = self.rrule.after(last_run_at_utc)
         if next_run_utc:
-            next = self.maybe_make_aware(next_run_utc)
-            now = self.maybe_make_aware(self.now())
-            delta = next - now
+            now_utc = self.now()
+            delta = next_run_utc - now_utc
             return delta
         return None
 

--- a/redbeat/schedules.py
+++ b/redbeat/schedules.py
@@ -1,13 +1,20 @@
 import celery
 from dateutil.rrule import rrule as dateutil_rrule
-from celery.schedules import BaseSchedule
-from celery.utils.time import (
-    localize,
-    timezone
-)
+try:  # celery 4.x
+    from celery.schedules import BaseSchedule as schedule
+    from celery.utils.time import (
+        localize,
+        timezone
+    )
+except ImportError:  # celery 3.x
+    from celery.schedules import schedule
+    from celery.utils.timeutils import (
+        localize,
+        timezone
+    )
 
 
-class rrule(BaseSchedule):
+class rrule(schedule):
     RRULE_REPR = """\
     <rrule: {0._freq} {0._interval}>\
     """

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,3 +7,4 @@ pytest-catchlog
 pytest-cov
 redis
 toX
+python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     install_requires=[
         'redis',
         'celery',
+        'python-dateutil'
     ],
     tests_require=[
         'pytest',

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -83,20 +83,6 @@ class test_RedBeatScheduler_schedule(RedBeatSchedulerTestBase):
         self.assertNotIn(up_next2.name, schedule)
         self.assertNotIn(later.name, schedule)
 
-    def test_schedule_removes_expired_schedule(self):
-        expired_schedule = mocked_expired_schedule()
-        due = self.create_entry(name='due', s=due_now).save()
-        expired = self.create_entry(name='expired', s=expired_schedule).save()
-
-        schedule = self.s.schedule
-
-        self.assertEqual(len(schedule), 1)
-
-        self.assertIn(due.name, schedule)
-        self.assertEqual(due.key, schedule[due.name].key)
-
-        self.assertNotIn(expired.name, schedule)
-
 
 class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,13 +1,18 @@
 from datetime import datetime, timedelta
 
-from celery.schedules import schedule
+from celery.schedules import (
+    schedule,
+    schedstate
+)
 try:  # celery 3.x
     from celery.utils.timeutils import maybe_timedelta
 except ImportError:  # celery 4.0
     from celery.utils.time import maybe_timedelta
 
-from mock import patch
-
+from mock import (
+    patch,
+    Mock
+)
 from basecase import RedBeatCase
 from redbeat import RedBeatScheduler
 
@@ -21,6 +26,20 @@ class mocked_schedule(schedule):
 
     def remaining_estimate(self, last_run_at):
         return self._remaining
+
+
+class mocked_expired_schedule(schedule):
+
+    def __init__(self):
+        self.nowfun = datetime.utcnow
+        self.run_every = Mock()
+        self.run_every.total_seconds.return_value = 1
+
+    def remaining_estimate(self, last_run_at):
+        return None
+
+    def is_due(self, last_run_at):
+        return schedstate(False, None)
 
 
 due_now = mocked_schedule(0)
@@ -63,6 +82,14 @@ class test_RedBeatScheduler_schedule(RedBeatSchedulerTestBase):
 
         self.assertNotIn(up_next2.name, schedule)
         self.assertNotIn(later.name, schedule)
+
+    def test_schedule_removes_expired_schedule(self):
+        expired_schedule = mocked_expired_schedule()
+        self.create_entry(name='expired', s=expired_schedule).save()
+
+        schedule = self.s.schedule
+
+        self.assertEqual(len(schedule), 0)
 
 
 class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -85,11 +85,17 @@ class test_RedBeatScheduler_schedule(RedBeatSchedulerTestBase):
 
     def test_schedule_removes_expired_schedule(self):
         expired_schedule = mocked_expired_schedule()
-        self.create_entry(name='expired', s=expired_schedule).save()
+        due = self.create_entry(name='due', s=due_now).save()
+        expired = self.create_entry(name='expired', s=expired_schedule).save()
 
         schedule = self.s.schedule
 
-        self.assertEqual(len(schedule), 0)
+        self.assertEqual(len(schedule), 1)
+
+        self.assertIn(due.name, schedule)
+        self.assertEqual(due.key, schedule[due.name].key)
+
+        self.assertNotIn(expired.name, schedule)
 
 
 class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -3,10 +3,12 @@ from datetime import (
     timedelta
 )
 from unittest import TestCase
+from mock import patch
 
 from redbeat.schedules import rrule
 
 
+@patch.object(rrule, 'now', datetime.utcnow)
 class test_rrule_remaining_estimate(TestCase):
 
     def test_freq(self):
@@ -33,6 +35,7 @@ class test_rrule_remaining_estimate(TestCase):
         self.assertEquals(eta_after_two_minutes, None)
 
 
+@patch.object(rrule, 'now', datetime.utcnow)
 class test_rrule_is_due(TestCase):
 
     def test_freq__starting_now(self):

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -4,12 +4,17 @@ from datetime import (
 )
 from unittest import TestCase
 from mock import patch
+try:  # celery 3.x
+    from celery.utils.timeutils import timezone
+except ImportError:  # celery 4.x
+    from celery.utils.time import timezone
 
 from redbeat.schedules import rrule
 
 
 @patch.object(rrule, 'now', datetime.utcnow)
 @patch.object(rrule, 'utc_enabled', True)
+@patch.object(rrule, 'tz', timezone.utc)
 class test_rrule_remaining_estimate(TestCase):
 
     def test_freq(self):
@@ -38,6 +43,7 @@ class test_rrule_remaining_estimate(TestCase):
 
 @patch.object(rrule, 'now', datetime.utcnow)
 @patch.object(rrule, 'utc_enabled', True)
+@patch.object(rrule, 'tz', timezone.utc)
 class test_rrule_is_due(TestCase):
 
     def test_freq__starting_now(self):

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -9,6 +9,7 @@ from redbeat.schedules import rrule
 
 
 @patch.object(rrule, 'now', datetime.utcnow)
+@patch.object(rrule, 'utc_enabled', True)
 class test_rrule_remaining_estimate(TestCase):
 
     def test_freq(self):
@@ -36,6 +37,7 @@ class test_rrule_remaining_estimate(TestCase):
 
 
 @patch.object(rrule, 'now', datetime.utcnow)
+@patch.object(rrule, 'utc_enabled', True)
 class test_rrule_is_due(TestCase):
 
     def test_freq__starting_now(self):

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,0 +1,76 @@
+from datetime import (
+    datetime,
+    timedelta
+)
+from unittest import TestCase
+
+from redbeat.schedules import rrule
+
+
+class test_rrule_remaining_estimate(TestCase):
+
+    def test_freq(self):
+        r = rrule('MINUTELY', dtstart=datetime.utcnow() + timedelta(minutes=1))
+        eta_from_now = r.remaining_estimate(datetime.utcnow())
+        eta_after_one_minute = r.remaining_estimate(datetime.utcnow() + timedelta(minutes=1))
+        self.assertTrue(eta_from_now.total_seconds() > 0)
+        self.assertTrue(eta_after_one_minute.total_seconds() > 0)
+
+    def test_freq__with_single_count(self):
+        r = rrule('MINUTELY', dtstart=datetime.utcnow() + timedelta(minutes=1), count=1)
+        eta_from_now = r.remaining_estimate(datetime.utcnow())
+        eta_after_one_minute = r.remaining_estimate(datetime.utcnow() + timedelta(minutes=1))
+        self.assertTrue(eta_from_now.total_seconds() > 0)
+        self.assertEquals(eta_after_one_minute, None)
+
+    def test_freq__with_multiple_count(self):
+        r = rrule('MINUTELY', dtstart=datetime.utcnow() + timedelta(minutes=1), count=2)
+        eta_from_now = r.remaining_estimate(datetime.utcnow())
+        eta_after_one_minute = r.remaining_estimate(datetime.utcnow() + timedelta(minutes=1))
+        eta_after_two_minutes = r.remaining_estimate(datetime.utcnow() + timedelta(minutes=2))
+        self.assertTrue(eta_from_now.total_seconds() > 0)
+        self.assertTrue(eta_after_one_minute.total_seconds() > 0)
+        self.assertEquals(eta_after_two_minutes, None)
+
+
+class test_rrule_is_due(TestCase):
+
+    def test_freq__starting_now(self):
+        r = rrule('MINUTELY', dtstart=datetime.utcnow())
+        # Assuming job was never run, i.e. last_run_at == epoch
+        is_due, next = r.is_due(datetime(1970, 1, 1))
+        self.assertTrue(is_due)
+        self.assertTrue(next > 0)
+
+    def test_freq__starts_after_one_minute(self):
+        r = rrule('MINUTELY', dtstart=datetime.utcnow() + timedelta(minutes=1))
+        is_due, next = r.is_due(datetime.utcnow())
+        self.assertFalse(is_due)
+        self.assertTrue(next > 0)
+
+    def test_freq__with_single_count(self):
+        r = rrule('MINUTELY', dtstart=datetime.utcnow(), count=1)
+        # If job was never run, it should be due and have
+        # no ETA for the following occurrence.
+        is_due, next = r.is_due(datetime(1970, 1, 1))
+        self.assertTrue(is_due)
+        self.assertEquals(next, None)
+        # It should not be due if it was already run once.
+        is_due, next = r.is_due(datetime.utcnow())
+        self.assertFalse(is_due)
+        self.assertEquals(next, None)
+
+    def test_freq__with_multiple_count(self):
+        r = rrule('MINUTELY', dtstart=datetime.utcnow(), count=2)
+        is_due, next = r.is_due(datetime(1970, 1, 1))
+        self.assertTrue(is_due)
+        self.assertTrue(next > 0)
+        # There should still be one more occurrence remaining
+        # if it was run once after dtstart.
+        is_due, next = r.is_due(datetime.utcnow())
+        self.assertFalse(is_due)
+        self.assertTrue(next > 0)
+        # There should be no more occurrences after one minute.
+        is_due, next = r.is_due(datetime.utcnow() + timedelta(minutes=1))
+        self.assertFalse(is_due)
+        self.assertEquals(next, None)


### PR DESCRIPTION
First pass at adding recurrence rule support (https://github.com/sibson/redbeat/issues/60). 
- Defines `rrule` scheduler class using `dateutil.rrule` for schedule calculations
  - `rrule` returns `None` for its `remaining_estimate` if there is no occurrence after the passed in datetime
- Updates JSON encoder/decoder to handle `rrule`
- Sets score to `-1` if there are no more occurrences, which causes it to be ignored by scheduler loop

TODO:
- [x] Celery 3 compatibility
- [x] Make sure timezones are handled correctly
  - Use Celery `maybe_make_aware` for handling timezones
- [x] Unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/61)
<!-- Reviewable:end -->
