### PR TITLE
use timezone aware timestamps

### DIFF
--- a/redbeat/decoder.py
+++ b/redbeat/decoder.py
@@ -8,6 +8,11 @@ try:
 except ImportError:
     import json
 
+try:  # celery 3.x
+    from celery.utils.timeutils import timezone
+except ImportError:  # celery 4.x
+    from celery.utils.time import timezone
+
 from celery.schedules import schedule, crontab
 from .schedules import rrule
 
@@ -23,7 +28,7 @@ class RedBeatJSONDecoder(json.JSONDecoder):
         objtype = d.pop('__type__')
 
         if objtype == 'datetime':
-            return datetime(**d)
+            return datetime(tzinfo=timezone.utc, **d)
 
         if objtype == 'interval':
             return schedule(run_every=d['every'], relative=d['relative'])

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import
 
-import time
+import calendar
 import warnings
 from datetime import datetime, MINYEAR
 from distutils.version import StrictVersion
@@ -20,10 +20,10 @@ from celery.beat import Scheduler, ScheduleEntry, DEFAULT_MAX_INTERVAL
 from celery.utils.log import get_logger
 from celery.signals import beat_init
 try:  # celery 3.x
-    from celery.utils.timeutils import humanize_seconds
+    from celery.utils.timeutils import humanize_seconds, timezone
     from kombu.utils import cached_property
 except ImportError:  # celery 4.x
-    from celery.utils.time import humanize_seconds
+    from celery.utils.time import humanize_seconds, timezone
     from kombu.utils.objects import cached_property
 from celery.app import app_or_default
 from celery.five import values
@@ -70,11 +70,13 @@ logger = get_logger(__name__)
 
 
 def to_timestamp(dt):
-    return time.mktime(dt.timetuple())
+    """ convert UTC datetime to seconds since the epoch """
+    return calendar.timegm(dt.timetuple())
 
 
-def from_timestamp(ts):
-    return datetime.fromtimestamp(ts)
+def from_timestamp(seconds):
+    """ convert seconds since the epoch to an UTC aware datetime """
+    return datetime.fromtimestamp(seconds, tz=timezone.utc)
 
 
 class RedBeatConfig(object):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -3,6 +3,10 @@ import json
 from unittest import TestCase
 
 from celery.schedules import schedule, crontab
+try:  # celery 3.x
+    from celery.utils.timeutils import timezone
+except ImportError:  # celery 4.x
+    from celery.utils.time import timezone
 
 from redbeat.decoder import RedBeatJSONDecoder, RedBeatJSONEncoder
 
@@ -82,7 +86,7 @@ class RedBeatJSONDecoderTestCase(JSONTestCase):
         result = self.loads(json.dumps(d))
 
         d.pop('__type__')
-        self.assertEqual(result, datetime(**d))
+        self.assertEqual(result, datetime(tzinfo=timezone.utc, **d))
 
     def test_schedule(self):
         d = self.schedule()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -114,7 +114,7 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
         self.assertLess(0.8, sleep)
         self.assertLess(sleep, 1.0)
 
-    def test_due_later_never_run(self):
+    def test_due_later_task_never_run(self):
         self.create_entry(s=self.due_later).save()
 
         with patch.object(self.s, 'send_task') as send_task:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,8 @@
+try:  # celery 3.x
+    from celery.utils.timeutils import maybe_make_aware
+except ImportError:  # celery 4.x
+    from celery.utils.time import maybe_make_aware
+
 from basecase import RedBeatCase
 from redbeat.schedulers import to_timestamp, from_timestamp
 
@@ -6,6 +11,8 @@ class Test_utils(RedBeatCase):
 
     def test_roundtrip(self):
         now = self.app.now()
+        # 3.x returns naive, but 4.x returns aware
+        now = maybe_make_aware(now)
 
         roundtripped = from_timestamp(to_timestamp(now))
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ deps=
     pytest-cov
 
 commands=
-    py.test [] tests
+    py.test [] tests {posargs}


### PR DESCRIPTION
In celery 4.x now() returns an aware datetime but 3.x uses naive.
By being aware we have a chance of supporting non-utc timezones
in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/65)
<!-- Reviewable:end -->
