### PR TITLE
Fixed serializing rrules in Celery 3

### DIFF
--- a/redbeat/decoder.py
+++ b/redbeat/decoder.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-import time
+import calendar
 from datetime import datetime
 
 try:
@@ -40,7 +40,7 @@ class RedBeatJSONDecoder(json.JSONDecoder):
             # Decode timestamp values into datetime objects
             for key in ['dtstart', 'until']:
                 if d[key] is not None:
-                    d[key] = datetime.fromtimestamp(d[key])
+                    d[key] = datetime.utcfromtimestamp(d[key])
             return rrule(**d)
 
         d['__type__'] = objtype
@@ -72,9 +72,9 @@ class RedBeatJSONEncoder(json.JSONEncoder):
             }
         if isinstance(obj, rrule):
             # Convert datetime objects to timestamps
-            dtstart_ts = time.mktime(obj.dtstart.timetuple()) \
+            dtstart_ts = calendar.timegm(obj.dtstart.timetuple()) \
                 if obj.dtstart else None
-            until_ts = time.mktime(obj.until.timetuple()) \
+            until_ts = calendar.timegm(obj.until.timetuple()) \
                 if obj.until else None
 
             return {

--- a/redbeat/decoder.py
+++ b/redbeat/decoder.py
@@ -70,12 +70,6 @@ class RedBeatJSONEncoder(json.JSONEncoder):
                 'day_of_month': obj._orig_day_of_month,
                 'month_of_year': obj._orig_month_of_year,
             }
-        if isinstance(obj, schedule):
-            return {
-                '__type__': 'interval',
-                'every': obj.run_every.total_seconds(),
-                'relative': bool(obj.relative),
-            }
         if isinstance(obj, rrule):
             # Convert datetime objects to timestamps
             dtstart_ts = time.mktime(obj.dtstart.timetuple()) \
@@ -101,5 +95,11 @@ class RedBeatJSONEncoder(json.JSONEncoder):
                 'byhour': obj.byhour,
                 'byminute': obj.byminute,
                 'bysecond': obj.bysecond
+            }
+        if isinstance(obj, schedule):
+            return {
+                '__type__': 'interval',
+                'every': obj.run_every.total_seconds(),
+                'relative': bool(obj.relative),
             }
         return super(RedBeatJSONEncoder, self).default(obj)

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -31,7 +31,10 @@ from kombu.utils.url import maybe_sanitize_url
 
 from redis.client import StrictRedis
 
-from .decoder import RedBeatJSONEncoder, RedBeatJSONDecoder
+from .decoder import (
+    RedBeatJSONEncoder, RedBeatJSONDecoder,
+    from_timestamp, to_timestamp
+    )
 
 CELERY_4_OR_GREATER = StrictVersion(celery_version) >= StrictVersion('4.0')
 
@@ -68,16 +71,6 @@ Couldn't add entry %r to redis schedule: %r. Contents: %r
 """
 
 logger = get_logger(__name__)
-
-
-def to_timestamp(dt):
-    """ convert UTC datetime to seconds since the epoch """
-    return calendar.timegm(dt.timetuple())
-
-
-def from_timestamp(seconds):
-    """ convert seconds since the epoch to an UTC aware datetime """
-    return datetime.fromtimestamp(seconds, tz=timezone.utc)
 
 
 class RedBeatConfig(object):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -9,6 +9,7 @@ except ImportError:  # celery 4.x
     from celery.utils.time import timezone
 
 from redbeat.decoder import RedBeatJSONDecoder, RedBeatJSONEncoder
+from redbeat.schedules import rrule
 
 
 class JSONTestCase(TestCase):
@@ -54,6 +55,29 @@ class JSONTestCase(TestCase):
         d.update(kwargs)
         return d
 
+    def rrule(self, **kwargs):
+        d = {
+            '__type__': 'rrule',
+            'freq': 5,
+            'dtstart': 1451473162.0,
+            'interval': 1,
+            'wkst': None,
+            'count': 1,
+            'until': None,
+            'bysetpos': None,
+            'bymonth': None,
+            'bymonthday': None,
+            'byyearday': None,
+            'byeaster': None,
+            'byweekno': None,
+            'byweekday': None,
+            'byhour': None,
+            'byminute': None,
+            'bysecond': None,
+        }
+        d.update(kwargs)
+        return d
+
 
 class RedBeatJSONEncoderTestCase(JSONTestCase):
 
@@ -76,6 +100,11 @@ class RedBeatJSONEncoderTestCase(JSONTestCase):
         c = crontab()
         result = self.dumps(c)
         self.assertEqual(result, json.dumps(self.crontab()))
+
+    def test_rrule(self):
+        r = rrule('MINUTELY', dtstart=datetime(2015, 12, 30, 12, 59, 22), count=1)
+        result = self.dumps(r)
+        self.assertEqual(result, json.dumps(self.rrule()))
 
 
 class RedBeatJSONDecoderTestCase(JSONTestCase):
@@ -103,3 +132,14 @@ class RedBeatJSONDecoderTestCase(JSONTestCase):
 
         d.pop('__type__')
         self.assertEqual(result, crontab())
+
+    def test_rrule(self):
+        d = self.rrule()
+
+        result = self.loads(json.dumps(d))
+
+        d.pop('__type__')
+        self.assertEqual(
+            result,
+            rrule('MINUTELY', dtstart=datetime(2015, 12, 30, 12, 59, 22), count=1),
+            )

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -59,7 +59,7 @@ class JSONTestCase(TestCase):
         d = {
             '__type__': 'rrule',
             'freq': 5,
-            'dtstart': 1451473162.0,
+            'dtstart': 1451480362,
             'interval': 1,
             'wkst': None,
             'count': 1,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -102,7 +102,7 @@ class RedBeatJSONEncoderTestCase(JSONTestCase):
         self.assertEqual(result, json.dumps(self.crontab()))
 
     def test_rrule(self):
-        r = rrule('MINUTELY', dtstart=datetime(2015, 12, 30, 12, 59, 22), count=1)
+        r = rrule('MINUTELY', dtstart=datetime(2015, 12, 30, 12, 59, 22, tzinfo=timezone.utc), count=1)
         result = self.dumps(r)
         self.assertEqual(result, json.dumps(self.rrule()))
 
@@ -141,5 +141,5 @@ class RedBeatJSONDecoderTestCase(JSONTestCase):
         d.pop('__type__')
         self.assertEqual(
             result,
-            rrule('MINUTELY', dtstart=datetime(2015, 12, 30, 12, 59, 22), count=1),
+            rrule('MINUTELY', dtstart=datetime(2015, 12, 30, 12, 59, 22, tzinfo=timezone.utc), count=1),
             )


### PR DESCRIPTION
In Celery 3 rrule inherits schedule so isinstance(rrule(...), schedule) is True. The encoder tries to serialize the rrule as a schedule object and causes an exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/68)
<!-- Reviewable:end -->
