### PR TITLE
Backport lock_timeout config

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.10.3 (2017-10-05)
+----------------------
+ - Backport change to allow configuration of lock_timeout
+
 0.10.0 (2017-10-03)
 ----------------------
  - SECURITY, redact password when logging Redis URL

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -271,6 +271,7 @@ class RedBeatScheduler(Scheduler):
         ensure_conf(app)  # set app.redbeat_conf
         self.lock_key = lock_key or app.redbeat_conf.lock_key
         self.lock_timeout = (lock_timeout or
+                             app.redbeat_conf.lock_timeout or
                              self.max_interval * 5 or
                              self.lock_timeout)
         super(RedBeatScheduler, self).__init__(app, **kwargs)


### PR DESCRIPTION
Without this backported change, there's no way to configure the lock_timeout for the RedbeatScheduler forcing every user to have a timeout of 25 minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/69)
<!-- Reviewable:end -->
