### PR TITLE
Fix support for Redis Sentinel

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -63,7 +63,8 @@ def redis(app=None):
         if conf.redis_url.startswith('redis-sentinel') and  'sentinels' in BROKER_TRANSPORT_OPTIONS:
             from redis.sentinel import Sentinel
             sentinel = Sentinel(BROKER_TRANSPORT_OPTIONS['sentinels'],
-                                socket_timeout=0.1)
+                                socket_timeout=0.1,
+                                decode_responses=True)
             service_name = BROKER_TRANSPORT_OPTIONS.get('service_name', 'master')
             app.redbeat_redis = sentinel.master_for(service_name,
                                                     socket_timeout=0.1)


### PR DESCRIPTION
Redis-py by default returns `bytes` rather than `str`. Redbeat expects
values are already decoded into `str`. `decode_responses=True` is passed
to `StrictRedis` but it was not passed to `Sentinel`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/75)
<!-- Reviewable:end -->
