### PR TITLE
Enhance support for Redis Sentinel, in particular - support password

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -249,6 +249,7 @@ configuration syntax is inspired from `celery-redis-sentinel
         'sentinels': [('192.168.1.1', 26379),
                       ('192.168.1.2', 26379),
                       ('192.168.1.3', 26379)],
+        'password': '123',
         'service_name': 'master',
         'socket_timeout': 0.1,
     }
@@ -263,6 +264,25 @@ Some notes about the configuration:
 
 * hostname and port are ignored within the actual URL. Sentinel uses transport options
   ``sentinels`` setting to create a ``Sentinel()`` instead of configuration URL.
+
+* ``password`` is going to be used for Celery queue backend as well.
+
+If other backend is configured for Celery queue use
+``REDBEAT_REDIS_URL`` instead of ``BROKER_URL`` and
+``REDBEAT_REDIS_OPTIONS`` instead of ``BROKER_TRANSPORT_OPTIONS``. to
+avoid conflicting options. Here follows the example:::
+
+    # celeryconfig.py
+    REDBEAT_REDIS_URL = 'redis-sentinel://redis-sentinel:26379/0'
+    REDBEAT_REDIS_OPTIONS = {
+        'sentinels': [('192.168.1.1', 26379),
+                      ('192.168.1.2', 26379),
+                      ('192.168.1.3', 26379)],
+        'password': '123',
+        'service_name': 'master',
+        'socket_timeout': 0.1,
+    }
+
 
 Development
 --------------

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -196,3 +196,30 @@ class SentinelRedBeatCase(AppCase):
     def test_sentinel_scheduler(self):
         redis_client = redis(app=self.app)
         assert 'Sentinel' in str(redis_client.connection_pool)
+
+
+class SeparateOptionsForSchedulerCase(AppCase):
+
+    config_dict = {
+            'REDBEAT_KEY_PREFIX': 'rb-tests:',
+            'REDBEAT_REDIS_URL': 'redis-sentinel://redis-sentinel:26379/0',
+            'REDBEAT_REDIS_OPTIONS': {
+                'sentinels': [('192.168.1.1', 26379),
+                              ('192.168.1.2', 26379),
+                              ('192.168.1.3', 26379)],
+                'password': '123',
+                'service_name': 'master',
+                'socket_timeout': 0.1,
+            },
+            'CELERY_RESULT_BACKEND' : 'redis-sentinel://redis-sentinel:26379/1',
+        }
+
+    def Celery(self, *args, **kwargs):
+        return UnitApp(*args, broker='redis-sentinel://redis-sentinel:26379/0', **kwargs)
+
+    def setup(self): # celery3
+        self.app.conf.add_defaults(deepcopy(self.config_dict))
+
+    def test_sentinel_scheduler(self):
+        redis_client = redis(app=self.app)
+        assert 'Sentinel' in str(redis_client.connection_pool)


### PR DESCRIPTION
Get options for Redis Sentinel from `REDBEAT_REDIS_OPTIONS` if available
and fall back to `BROKER_TRANSPORT_OPTIONS` otherwise. Add support for
password.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/76)
<!-- Reviewable:end -->
