### PR TITLE
Reconnect to Redis on connection or time-out error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -281,7 +281,13 @@ avoid conflicting options. Here follows the example:::
         'password': '123',
         'service_name': 'master',
         'socket_timeout': 0.1,
+        'retry_period': 60,
     }
+
+If ``retry_period`` is given, retry connection for ``retry_period``
+seconds. If not set, retrying mechanism is not triggered. If set
+to ``-1`` retry infinitely.
+
 
 
 Development

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,4 +7,5 @@ pytest-catchlog
 pytest-cov
 python-dateutil
 redis
+tenacity
 tox

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
     install_requires=[
         'redis',
         'celery',
-        'python-dateutil'
+        'python-dateutil',
+        'tenacity'
     ],
     tests_require=[
         'pytest',

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -20,7 +20,7 @@ from mock import (
 )
 from basecase import RedBeatCase, AppCase
 from redbeat import RedBeatScheduler
-from redbeat.schedulers import redis
+from redbeat.schedulers import get_redis
 
 
 class mocked_schedule(schedule):
@@ -168,7 +168,7 @@ class NotSentinelRedBeatCase(AppCase):
         pass
 
     def test_sentinel_scheduler(self):
-        redis_client = redis(app=self.app)
+        redis_client = get_redis(app=self.app)
         assert 'Sentinel' not in str(redis_client.connection_pool)
 
 class SentinelRedBeatCase(AppCase):
@@ -194,7 +194,7 @@ class SentinelRedBeatCase(AppCase):
         self.app.conf.add_defaults(deepcopy(self.config_dict))
 
     def test_sentinel_scheduler(self):
-        redis_client = redis(app=self.app)
+        redis_client = get_redis(app=self.app)
         assert 'Sentinel' in str(redis_client.connection_pool)
 
 
@@ -221,5 +221,5 @@ class SeparateOptionsForSchedulerCase(AppCase):
         self.app.conf.add_defaults(deepcopy(self.config_dict))
 
     def test_sentinel_scheduler(self):
-        redis_client = redis(app=self.app)
+        redis_client = get_redis(app=self.app)
         assert 'Sentinel' in str(redis_client.connection_pool)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps=
     pytest-cov
     python-dateutil
     redis
+    tenacity
 
 commands=
     py.test [] tests {posargs}


### PR DESCRIPTION
Otherwise RedBeat scheduler quits on connection error, e.g. when Redis
is restarted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sibson/redbeat/80)
<!-- Reviewable:end -->
