### PR TITLE
fix disabling redbeat_lock feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,8 +75,7 @@ A prefix for all keys created by RedBeat, defaults to ``'redbeat'``.
 ``redbeat_lock_key``
 ~~~~~~~~~~~~~~~~~~~~
 
-Key used to ensure only a single beat instance runs at a time,
-defaults to ``'<redbeat_key_prefix>:lock'``.
+Key used to ensure only a single beat instance runs at a time. Omit or set to None to disable this feature.
 
 ``redbeat_lock_timeout``
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -141,7 +141,7 @@ class RedBeatConfig(object):
         self.key_prefix = self.either_or('redbeat_key_prefix', 'redbeat:')
         self.schedule_key = self.key_prefix + ':schedule'
         self.statics_key = self.key_prefix + ':statics'
-        self.lock_key = self.either_or('redbeat_lock_key', self.key_prefix + ':lock')
+        self.lock_key = self.either_or('redbeat_lock_key', None)
         self.lock_timeout = self.either_or('redbeat_lock_timeout', None)
         self.redis_url = self.either_or('redbeat_redis_url', app.conf['BROKER_URL'])
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ class test_RedBeatConfig(AppCase):
     def test_other_keys(self):
         self.assertEqual(self.conf.schedule_key, self.conf.key_prefix + ':schedule')
         self.assertEqual(self.conf.statics_key, self.conf.key_prefix + ':statics')
-        self.assertEqual(self.conf.lock_key, self.conf.key_prefix + ':lock')
+        self.assertEqual(self.conf.lock_key, None)
 
     @pytest.mark.skipif(not CELERY_4_OR_GREATER, reason="requires Celery >= 4.x")
     def test_key_prefix_override_4(self):


### PR DESCRIPTION
In situations where RedBeat lock is not needed we are unable to disable this feature.  This PR allows user to disable lock by omitting or assigning None in the config.
https://github.com/sibson/redbeat/issues/101