### PR TITLE
Added version specifier for redis-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'Operating System :: OS Independent',
     ],
     install_requires=[
-        'redis',
+        'redis<3.0',
         'celery',
         'python-dateutil',
         'tenacity'


### PR DESCRIPTION
`redis-py` 3.0 has some backward incompatible changes which break redbeat (but don't break the tests which use fakeredis).
See [CHANGES](https://github.com/andymccurdy/redis-py/blob/ac6b286242b3054b5645e67e58ce8340ccf2d091/CHANGES#L42)