### PR TITLE
Add ability to connect to Redis with client SSL/TLS certificates.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,11 @@ You can add any of the following parameters to your Celery configuration
 URL to redis server used to store the schedule, defaults to value of
 `broker_url`_.
 
+``redbeat_redis_use_ssl``
+~~~~~~~~~~~~~~~~~~~~~
+Additional SSL options used when using the ``rediss`` scheme in
+``redbeat_redis_url``, defaults to the values of `broker_use_ssl`_.
+
 ``redbeat_key_prefix``
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -84,6 +89,7 @@ Defaults to five times of the default scheduler's loop interval
 See the `beat_max_loop_interval`_ Celery docs about for more information.
 
 .. _`broker_url`: http://docs.celeryproject.org/en/4.0/userguide/configuration.html#std:setting-broker_url
+.. _`broker_use_ssl`: http://docs.celeryproject.org/en/4.0/userguide/configuration.html#std:setting-broker_use_ssl
 .. _`beat_max_loop_interval`: http://docs.celeryproject.org/en/4.0/userguide/configuration.html#std:setting-beat_max_loop_interval
 
 Celery 3.x config names
@@ -96,6 +102,7 @@ Celery 3.x.
 **Celery 4.x**                       **Celery 3.x**
 ===================================  ==============================================
 ``redbeat_redis_url``                ``REDBEAT_REDIS_URL``
+``redbeat_redis_use_ssl``            ``REDBEAT_REDIS_USE_SSL``
 ``redbeat_key_prefix``               ``REDBEAT_KEY_PREFIX``
 ``redbeat_lock_key``                 ``REDBEAT_LOCK_KEY``
 ``redbeat_lock_timeout``             ``REDBEAT_LOCK_TIMEOUT``

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import calendar
 import logging
 import warnings
+import ssl
 from datetime import datetime, MINYEAR
 from distutils.version import StrictVersion
 
@@ -118,6 +119,11 @@ def get_redis(app=None):
                                 password=redis_options.get('password'),
                                 decode_responses=True)
             connection = sentinel.master_for(redis_options.get('service_name', 'master'))
+        elif conf.redis_url.startswith('rediss'):
+            ssl_options = { 'ssl_cert_reqs': ssl.CERT_REQUIRED }
+            if isinstance(conf.redis_use_ssl, dict):
+                ssl_options.update(conf.redis_use_ssl)
+            connection = StrictRedis.from_url(conf.redis_url, decode_responses=True, **ssl_options)
         else:
             connection = StrictRedis.from_url(conf.redis_url, decode_responses=True)
 
@@ -154,6 +160,7 @@ class RedBeatConfig(object):
         self.lock_key = self.either_or('redbeat_lock_key', self.key_prefix + ':lock')
         self.lock_timeout = self.either_or('redbeat_lock_timeout', None)
         self.redis_url = self.either_or('redbeat_redis_url', app.conf['BROKER_URL'])
+        self.redis_use_ssl = self.either_or('redbeat_redis_use_ssl', app.conf['BROKER_USE_SSL'])
 
     @property
     def schedule(self):


### PR DESCRIPTION
SSL connections were supported before, but there was no way to provide
client certificates.  This changeset introduces REDBEAT_REDIS_USE_SSL to
provide further SSL options, with a fallback to BROKER_USE_SSL,
mimicking the behavior we have we REDBEAT_REDIS_URL and BROKER_URL.

Small mention in #99 though they didn't need client certs there.