### PR TITLE
Fix duplicate runs of tasks

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -279,8 +279,12 @@ class RedBeatSchedulerEntry(ScheduleEntry):
             'schedule': self.schedule,
             'enabled': self.enabled,
         }
+        meta = {
+            'last_run_at': self.last_run_at,
+        }
         with get_redis(self.app).pipeline() as pipe:
             pipe.hset(self.key, 'definition', json.dumps(definition, cls=RedBeatJSONEncoder))
+            pipe.hsetnx(self.key, 'meta', json.dumps(meta, cls=RedBeatJSONEncoder))
             zadd(pipe, self.app.redbeat_conf.schedule_key, {self.key: self.score})
             pipe.execute()
 

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -45,7 +45,7 @@ class test_RedBeatEntry(RedBeatCase):
 
         loaded = RedBeatSchedulerEntry.from_key(initial.key, self.app)
         self.assertEqual(initial.task, loaded.task)
-        self.assertIsNone(loaded.last_run_at)
+        self.assertIsNotNone(loaded.last_run_at)
 
     def test_next(self):
         initial = self.create_entry().save()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -104,11 +104,9 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
 
         with patch.object(self.s, 'send_task') as send_task:
             sleep = self.s.tick()
-            send_task.assert_called_with(e.task, e.args, e.kwargs, **self.s._maybe_due_kwargs)
-            # would be more correct to
-            # self.assertFalse(send_task.called)
+            self.assertFalse(send_task.called)
 
-        self.assertEqual(sleep, 1.0)
+        self.assertLess(sleep, 1.0)
 
     def test_due_next_just_ran(self):
         e = self.create_entry(name='next', s=due_next)
@@ -129,8 +127,12 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
 
         self.assertEqual(sleep, self.s.max_interval)
 
-    def test_due_now_never_run(self):
-        e = self.create_entry(name='now', s=due_now).save()
+    def test_due_now(self):
+        e = self.create_entry(
+            name='now',
+            s=due_now,
+            last_run_at=datetime.utcnow() - timedelta(seconds=1),
+            ).save()
 
         with patch.object(self.s, 'send_task') as send_task:
             sleep = self.s.tick()


### PR DESCRIPTION
This fixes #81 and fixes #79.
This is a behavior change. Until now, tasks with a schedule indicating that they should have already run (such as crontabs but also rrules with `dtstart<now`) would be considered as "should run now". The problem is that this `now` is not immediate, since the task might not be loaded at the next tick. Instead, the task would be loaded in a tick which is proximate to the time it should run (the `score`). The task would then be run since it is due but the next instance would soon also be due and will also be run. I think celery takes this into account as it doesn't leave `last_run_at` as `None`. This change saves `last_run_at` metadata on `save()`, thus changing the result of further `is_due` calls until the task is actually due.
This might break code which expects this extra call but I don't think this is the obvious expected behavior.