### PR TITLE
avoid unneeded second circleci test run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   # TODO: add caching
-  python37:
+  python:
     docker:
       - image: circleci/python:3.7
 
@@ -27,4 +27,4 @@ workflows:
   version: 2
   UnitTests:
     jobs:
-      - python37
+      - python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,37 +19,12 @@ jobs:
                 TEST_RESULTS_DIR: /tmp/tox/
           command: |
             mkdir /tmp/tox
-            tox --skip-missing-interpreters
+            tox
       - store_test_results:
           path: /tmp/tox
-  python27:
-    docker:
-      - image: circleci/python:2.7
-
-    steps:
-      - checkout
-
-      - run:
-          name: Install Tox
-          command: |
-            pip install --user tox
-            echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
-            source $BASH_ENV
-      - run:
-          name: Run Tests
-          environment:
-                TEST_RESULTS_DIR: /tmp/tox/
-          command: |
-            mkdir /tmp/tox
-            tox --skip-missing-interpreters
-      - store_test_results:
-          path: /tmp/tox
-
-
 
 workflows:
   version: 2
-  testing:
+  UnitTests:
     jobs:
       - python37
-      - python27


### PR DESCRIPTION
The py37 images contains py27 as well so tox can run all tests on a
single image.