### PR TITLE
Enable testing with redis-py 3.2

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 celery
-fakeredis>=0.8.1
+fakeredis>=1.0.3
 mock
 nose
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps=
     pytest-cov
     python-dateutil
     redis2: redis<3
-    redis3: redis>=3,<3.2
+    redis3: redis>=3
     tenacity
 
 commands=


### PR DESCRIPTION
Tests now pass with `redis-py` 3.2 using new `fakeredis` version.