### PR TITLE
Keep the timezone info in the encoded json

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -99,6 +99,17 @@ class RedBeatJSONEncoderTestCase(JSONTestCase):
 
         self.assertEqual(result, json.dumps(expected))
 
+    def test_datetime_with_tz(self):
+        dt = datetime.now().replace(tzinfo=timezone.get_timezone('US/Eastern'))
+        result = self.dumps(dt)
+
+        expected = self.datetime(timezone='US/Eastern')
+        for key in (k for k in expected if hasattr(dt, k)):
+            expected[key] = getattr(dt, key)
+
+        self.assertEqual(result, json.dumps(expected))
+
+
     def test_schedule(self):
         s = schedule(run_every=60.0)
         result = self.dumps(s)
@@ -192,6 +203,16 @@ class RedBeatJSONDecoderTestCase(JSONTestCase):
 
         d.pop('__type__')
         self.assertEqual(result, datetime(tzinfo=timezone.utc, **d))
+
+    def test_datetime_with_tz(self):
+        d = self.datetime(timezone="US/Eastern")
+
+        result = self.loads(json.dumps(d))
+
+        d.pop('__type__')
+        d.pop('timezone')
+        self.assertEqual(result, datetime(tzinfo=timezone.get_timezone("US/Eastern"), **d))
+
 
     def test_schedule(self):
         d = self.schedule()


### PR DESCRIPTION
With celery to 4.4

With `enable_utc = False` and `timezone = 'Asia/Shanghai`(or any timezone east than UTC, for example `Asia/Paris`), redbeat will first create a `last_run_at` without timezone, and set it to meta. If current time is 10:00 in UTC and 11:00 in Paris or 18:00 in Shanghai

Now I use Paris timezone, the time  11:00 will be saved to redis, and then it will be decoded to 11:00 with UTC.
When try to shot a new task at 11:10 in Paris, It read `last_run_at` is 11:00UTC, or 12:00 in Paris, so it will not shot the task, until 12:00 in Paris.

In East Earth, such as UTC-7, when start the beat at any time, the future scheduled task will shot, 7 hours before the config time.

So, just keep the timezone info same in the json string can solve the problem above, and the old decode method is absolutely wrong, it caused the above problem.
