### PR TITLE
Allow create schedule entries from dict

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -204,6 +204,9 @@ class RedBeatSchedulerEntry(ScheduleEntry):
     def __init__(
         self, name=None, task=None, schedule=None, args=None, kwargs=None, enabled=True, **clsargs
     ):
+        if isinstance(schedule, dict):
+            # Decode dict to schedule entry
+            schedule = RedBeatJSONDecoder().dict_to_object(schedule)
         super(RedBeatSchedulerEntry, self).__init__(
             name=name, task=task, schedule=schedule, args=args, kwargs=kwargs, **clsargs
         )

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -33,6 +33,25 @@ class test_RedBeatEntry(RedBeatCase):
         self.assertEqual(redis.zrank(self.app.redbeat_conf.schedule_key, e.key), 0)
         self.assertEqual(redis.zscore(self.app.redbeat_conf.schedule_key, e.key), e.score)
 
+    def test_create_from_dict_schedule(self):
+        entry_data = {
+            'name': 'test2',
+            'task': 'tasks.test',
+            's': {
+                '__type__': 'crontab',
+                'minute': '*/5',
+                'hour': '*',
+                'day_of_month': '*',
+            },
+            'args': None,
+            'kwargs': CELERY_CONFIG_DEFAULT_KWARGS,
+            'options': {},
+            'enabled': True,
+        }
+        # verify entry can be created successfully without AttributeError
+        e = self.create_entry(**entry_data)
+        e.save()
+
     def test_from_key_nonexistent_key(self):
         with self.assertRaises(KeyError):
             RedBeatSchedulerEntry.from_key('doesntexist', self.app)


### PR DESCRIPTION
This commit is to allow creating RedBeatScheuleEntry directly from data loaded from config files. The reason is that I would like to load static beat schedules for Celery from a YAML/JSON config file.  Without this commit the following exception is raised.

```
redbeat/schedulers.py:209: in __init__
    args=args, kwargs=kwargs, **clsargs)
../venv/lib/python3.6/site-packages/celery/beat.py:127: in __init__
    self.schedule = maybe_schedule(schedule, relative, app=self.app)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

s = {'__type__': 'crontab', 'day_of_month': '*', 'hour': '*', 'minute': '*/5'}, relative = False, app = <Celery celery.tests at 0x7fadb42438>

    def maybe_schedule(s, relative=False, app=None):
        """Return schedule from number, timedelta, or actual schedule."""
        if s is not None:
            if isinstance(s, numbers.Number):
                s = timedelta(seconds=s)
            if isinstance(s, timedelta):
                return schedule(s, relative, app=app)
            else:
>               s.app = app
E               AttributeError: 'dict' object has no attribute 'app'

../venv/lib/python3.6/site-packages/celery/schedules.py:667: AttributeError
```