### PR TITLE
Support for Celery 5 (RC)

### DIFF
--- a/redbeat/decoder.py
+++ b/redbeat/decoder.py
@@ -1,12 +1,8 @@
 # coding: utf-8
 
 import calendar
+import json
 from datetime import datetime
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
 
 from celery.schedules import schedule, crontab
 from celery.utils.time import timezone, FixedOffset

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -5,15 +5,11 @@
 
 from __future__ import absolute_import
 
+import json
 import logging
 import warnings
 import ssl
 from datetime import datetime, MINYEAR
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
 
 from celery.beat import Scheduler, ScheduleEntry, DEFAULT_MAX_INTERVAL
 from celery.utils.log import get_logger
@@ -21,7 +17,6 @@ from celery.signals import beat_init
 from celery.utils.time import humanize_seconds
 from kombu.utils.objects import cached_property
 from celery.app import app_or_default
-from celery.five import values
 from kombu.utils.url import maybe_sanitize_url
 from tenacity import (
     retry,
@@ -470,7 +465,7 @@ class RedBeatScheduler(Scheduler):
 
         remaining_times = []
         try:
-            for entry in values(self.schedule):
+            for entry in self.schedule.values():
                 next_time_to_run = self.maybe_due(entry, **self._maybe_due_kwargs)
                 if next_time_to_run:
                     remaining_times.append(next_time_to_run)

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,17 @@
 [tox]
-envlist=py{35,37,38}
+envlist =
+    py{35,36,37,38}-celery4
+    py{36,37,38}-celery5
 
 [testenv]
 deps=
-    celery>=4.2
+    celery4: celery>=4.2,<5.0
+    celery5: celery>=5.0.0rc3
     fakeredis
     mock
-    celery3: nose
     pytest
     pytest-cov
+    pytest-celery
     python-dateutil
     redis>=3
     tenacity


### PR DESCRIPTION
This adds celery 5 RC to tox config and fixes compatibility (`celery.five` removed). Also removed `simplejson` shim.