### PR TITLE
allow for lowercase redbeat_redis_options config

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -119,9 +119,13 @@ def get_redis(app=None):
     app = app_or_default(app)
     conf = ensure_conf(app)
     if not hasattr(app, 'redbeat_redis') or app.redbeat_redis is None:
-        redis_options = conf.app.conf.get(
-            'REDBEAT_REDIS_OPTIONS', conf.app.conf.get('BROKER_TRANSPORT_OPTIONS', {})
+        redis_options = conf.app.conf.first(
+            "redbeat_redis_options", "REDBEAT_REDIS_OPTIONS"
         )
+        if redis_options is None:
+            redis_options = conf.app.conf.first(
+                "BROKER_TRANSPORT_OPTIONS", "broker_transport_options"
+            ) or {}
         retry_period = redis_options.get('retry_period')
         if conf.redis_url.startswith('redis-sentinel') and 'sentinels' in redis_options:
             from redis.sentinel import Sentinel

--- a/tests/basecase.py
+++ b/tests/basecase.py
@@ -12,7 +12,9 @@ class AppCase(TestCase):
             self.app = TestApp(config=self.config_dict)
         except Exception:
             self.app = TestApp()
-        self.setup()
+
+        if hasattr(self, 'setup'):
+            self.setup()
 
 
 class RedBeatCase(AppCase):


### PR DESCRIPTION
Code now accepts redis_options via `app.conf.REDBEAT_REDIS_OPTIONS` or `app.conf.redbeat_redis_options`  to match celery's 4.x case style. 