### PR TITLE
use inherited max_interval to set lock_timeout when no value is given

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -365,6 +365,8 @@ class RedBeatScheduler(Scheduler):
 
     def __init__(self, app, lock_key=None, lock_timeout=None, **kwargs):
         ensure_conf(app)  # set app.redbeat_conf
+        super(RedBeatScheduler, self).__init__(app, **kwargs)
+
         self.lock_key = lock_key or app.redbeat_conf.lock_key
         self.lock_timeout = (
             lock_timeout
@@ -372,7 +374,6 @@ class RedBeatScheduler(Scheduler):
             or self.max_interval * 5
             or self.lock_timeout
         )
-        super(RedBeatScheduler, self).__init__(app, **kwargs)
 
     def setup_schedule(self):
         # cleanup old static schedule entries

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 import unittest
 
+from celery.beat import DEFAULT_MAX_INTERVAL
 from celery.schedules import schedule, schedstate
 from celery.utils.time import maybe_timedelta
 
@@ -317,3 +318,33 @@ class SSLConnectionToRedisNoCerts(AppCase):
         assert 'ssl_keyfile' not in redis_client.connection_pool.connection_kwargs
         assert 'ssl_certfile' not in redis_client.connection_pool.connection_kwargs
         assert 'ssl_ca_certs' not in redis_client.connection_pool.connection_kwargs
+
+
+class RedBeatLockTimeoutDefaultValues(RedBeatCase):
+    def test_no_values(self):
+        scheduler = RedBeatScheduler(app=self.app)
+        assert DEFAULT_MAX_INTERVAL * 5 == scheduler.lock_timeout
+        assert DEFAULT_MAX_INTERVAL == scheduler.max_interval
+
+
+class RedBeatLockTimeoutCustomMaxInterval(RedBeatCase):
+    config_dict = {
+        'beat_max_loop_interval': 5,
+    }
+
+    def test_no_lock_timeout(self):
+        scheduler = RedBeatScheduler(app=self.app)
+        assert self.config_dict['beat_max_loop_interval'] * 5 == scheduler.lock_timeout
+        assert self.config_dict['beat_max_loop_interval'] == scheduler.max_interval
+
+
+class RedBeatLockTimeoutCustomAll(RedBeatCase):
+    config_dict = {
+        'beat_max_loop_interval': 7,
+        'redbeat_lock_timeout': 13,
+    }
+
+    def test_custom_lock_timeout(self):
+        scheduler = RedBeatScheduler(app=self.app)
+        assert self.config_dict['beat_max_loop_interval'] == scheduler.max_interval
+        assert self.config_dict['redbeat_lock_timeout'] == scheduler.lock_timeout


### PR DESCRIPTION
`RedBeatScheduler` doesn't use inherited max_interval to set lock_timeout.

The values set by `--max-interval=5` OR `celery.conf.beat_max_loop_interval = 5` doesn't get applied to self.lock_timeout.

The `self.lock_timeout` in `tick()` will therefore be 1500secs (300 * 5) even though self.max_interval is 5 secs after calling `super()` in the `__init__` function.
