### PR TITLE
support lowercase redbeat_redis_options conf

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -119,9 +119,7 @@ def get_redis(app=None):
     app = app_or_default(app)
     conf = ensure_conf(app)
     if not hasattr(app, 'redbeat_redis') or app.redbeat_redis is None:
-        redis_options = conf.app.conf.get(
-            'REDBEAT_REDIS_OPTIONS', conf.app.conf.get('BROKER_TRANSPORT_OPTIONS', {})
-        )
+        redis_options = conf.redbeat_redis_options
         retry_period = redis_options.get('retry_period')
         if conf.redis_url.startswith('redis-sentinel') and 'sentinels' in redis_options:
             from redis.sentinel import Sentinel
@@ -174,6 +172,7 @@ class RedBeatConfig(object):
         self.lock_timeout = self.either_or('redbeat_lock_timeout', None)
         self.redis_url = self.either_or('redbeat_redis_url', app.conf['BROKER_URL'])
         self.redis_use_ssl = self.either_or('redbeat_redis_use_ssl', app.conf['BROKER_USE_SSL'])
+        self.redbeat_redis_options = self.either_or('redbeat_redis_options', app.conf['BROKER_TRANSPORT_OPTIONS'])
 
     @property
     def schedule(self):

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -172,7 +172,9 @@ class RedBeatConfig(object):
         self.lock_timeout = self.either_or('redbeat_lock_timeout', None)
         self.redis_url = self.either_or('redbeat_redis_url', app.conf['BROKER_URL'])
         self.redis_use_ssl = self.either_or('redbeat_redis_use_ssl', app.conf['BROKER_USE_SSL'])
-        self.redbeat_redis_options = self.either_or('redbeat_redis_options', app.conf['BROKER_TRANSPORT_OPTIONS'])
+        self.redbeat_redis_options = self.either_or(
+            'redbeat_redis_options', app.conf['BROKER_TRANSPORT_OPTIONS']
+        )
 
     @property
     def schedule(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -213,7 +213,11 @@ class SentinelRedBeatCase(AppCase):
         assert 'Sentinel' in str(redis_client.connection_pool)
 
     def test_sentinel_scheduler_options(self):
-        for options in ["BROKER_TRANSPORT_OPTIONS", "redbeat_redis_options", "REDBEAT_REDIS_OPTIONS"]:
+        for options in [
+            "BROKER_TRANSPORT_OPTIONS",
+            "redbeat_redis_options",
+            "REDBEAT_REDIS_OPTIONS",
+        ]:
             config = deepcopy(self.config_dict)
             config[options] = self.BROKER_TRANSPORT_OPTIONS
             self.app.conf.clear()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -196,20 +196,30 @@ class SentinelRedBeatCase(AppCase):
         'REDBEAT_KEY_PREFIX': 'rb-tests:',
         'redbeat_key_prefix': 'rb-tests:',
         'BROKER_URL': 'redis-sentinel://redis-sentinel:26379/0',
-        'BROKER_TRANSPORT_OPTIONS': {
-            'sentinels': [('192.168.1.1', 26379), ('192.168.1.2', 26379), ('192.168.1.3', 26379)],
-            'service_name': 'master',
-            'socket_timeout': 0.1,
-        },
         'CELERY_RESULT_BACKEND': 'redis-sentinel://redis-sentinel:26379/1',
+    }
+    BROKER_TRANSPORT_OPTIONS = {
+        'sentinels': [('192.168.1.1', 26379), ('192.168.1.2', 26379), ('192.168.1.3', 26379)],
+        'service_name': 'master',
+        'socket_timeout': 0.1,
     }
 
     def setup(self):  # celery3
         self.app.conf.add_defaults(deepcopy(self.config_dict))
 
     def test_sentinel_scheduler(self):
+        self.app.conf.update({'BROKER_TRANSPORT_OPTIONS': self.BROKER_TRANSPORT_OPTIONS})
         redis_client = get_redis(app=self.app)
         assert 'Sentinel' in str(redis_client.connection_pool)
+
+    def test_sentinel_scheduler_options(self):
+        for options in ["BROKER_TRANSPORT_OPTIONS", "redbeat_redis_options", "REDBEAT_REDIS_OPTIONS"]:
+            config = deepcopy(self.config_dict)
+            config[options] = self.BROKER_TRANSPORT_OPTIONS
+            self.app.conf.clear()
+            self.app.conf.update(config)
+            redis_client = get_redis(app=self.app)
+            assert 'Sentinel' in str(redis_client.connection_pool)
 
 
 class SeparateOptionsForSchedulerCase(AppCase):


### PR DESCRIPTION
As we support both **redbeat_redis_url** & **REDBEAT_REDIS_URL**, it's weird that we use lowercase **redbeat_redis_url** and upper case **REDBEAT_REDIS_OPTIONS** in our conf. 
Also celery 4 suggest to use lowercase for config which also mentioned in RedBeat docs.