### PR TITLE
support redis sentinel with password

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -56,6 +56,7 @@ configuration syntax is inspired from `celery-redis-sentinel
         'db': 0,
         'service_name': 'master',
         'socket_timeout': 0.1,
+        'sentinel_kwargs': {'password'： 'sentinel_password'}
     }
 
     CELERY_RESULT_BACKEND = 'redis-sentinel://redis-sentinel:26379/1'
@@ -73,6 +74,9 @@ Some notes about the configuration:
 
 * ``db`` is optional and defaults to ``0``.
 
+* ``sentinel_kwargs`` is optional and is passed to ``redis.Sentinel()``.For example, if sentinel has set a password,
+  ``sentinel_kwargs`` can set to ``{'password'： 'sentinel_password'}``
+
 If other backend is configured for Celery queue use
 ``REDBEAT_REDIS_URL`` instead of ``BROKER_URL`` and
 ``REDBEAT_REDIS_OPTIONS`` instead of ``BROKER_TRANSPORT_OPTIONS``. to
@@ -87,6 +91,7 @@ avoid conflicting options. Here follows the example:::
         'password': '123',
         'service_name': 'master',
         'socket_timeout': 0.1,
+        'sentinel_kwargs': {'password'： 'xxxx'}
         'retry_period': 60,
     }
 

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -130,6 +130,7 @@ def get_redis(app=None):
                 password=redis_options.get('password'),
                 db=redis_options.get('db', 0),
                 decode_responses=True,
+                sentinel_kwargs=redis_options.get('sentinel_kwargs', None)
             )
             connection = sentinel.master_for(redis_options.get('service_name', 'master'))
         elif conf.redis_url.startswith('rediss'):

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -130,7 +130,7 @@ def get_redis(app=None):
                 password=redis_options.get('password'),
                 db=redis_options.get('db', 0),
                 decode_responses=True,
-                sentinel_kwargs=redis_options.get('sentinel_kwargs', None)
+                sentinel_kwargs=redis_options.get('sentinel_kwargs')
             )
             connection = sentinel.master_for(redis_options.get('service_name', 'master'))
         elif conf.redis_url.startswith('rediss'):

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -130,7 +130,7 @@ def get_redis(app=None):
                 password=redis_options.get('password'),
                 db=redis_options.get('db', 0),
                 decode_responses=True,
-                sentinel_kwargs=redis_options.get('sentinel_kwargs')
+                sentinel_kwargs=redis_options.get('sentinel_kwargs'),
             )
             connection = sentinel.master_for(redis_options.get('service_name', 'master'))
         elif conf.redis_url.startswith('rediss'):


### PR DESCRIPTION
As we just set the host and port for the sentinel, if the sentinel has set password and `NOAUTH` error will return.   
So a new option `sentinel_kwargs`  is added, user is free to set any params as they wanted including password for the sentinel.