### PR TITLE
Use final 3.10 release for testing and remove 3.6 support

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.2]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.0-rc.2
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           pip install flake8 flake8-black flake8-isort

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'Topic :: Software Development :: Object Brokering',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-celery4
-    py{36,37,38,39,310}-celery5
+    py{37,38,39,310}-celery4
+    py{37,38,39,310}-celery5
 
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -15,7 +14,7 @@ python =
 [testenv]
 deps=
     celery4: celery>=4.2,<5.0
-    celery5: celery>=5.0.0rc3
+    celery5: celery>=5.0
     fakeredis
     pytest
     pytest-cov


### PR DESCRIPTION
### CHANGES
This PR changes the list of Python versions used for testing to include the final 3.10 release and remove already deprecated 3.6