### PR TITLE
using uuid-$hostname-$pid replace default uuid as lock token.

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -3,9 +3,11 @@
 # of the License at http://www.apache.org/licenses/LICENSE-2.0
 # Copyright 2015 Marc Sibson
 
-
+import os
 import json
 import ssl
+import socket
+import uuid
 import warnings
 from datetime import MINYEAR, datetime
 
@@ -163,11 +165,20 @@ class RedBeatConfig:
         self.schedule_key = self.key_prefix + ':schedule'
         self.statics_key = self.key_prefix + ':statics'
         self.lock_key = self.either_or('redbeat_lock_key', self.key_prefix + ':lock')
+        self.lock_token = self.generate_lock_token()
         self.lock_timeout = self.either_or('redbeat_lock_timeout', None)
         self.redis_url = self.either_or('redbeat_redis_url', app.conf['BROKER_URL'])
         self.redis_use_ssl = self.either_or('redbeat_redis_use_ssl', app.conf['BROKER_USE_SSL'])
         self.redbeat_redis_options = self.either_or(
             'redbeat_redis_options', app.conf['BROKER_TRANSPORT_OPTIONS']
+        )
+
+    @staticmethod
+    def generate_lock_token():
+        return '{uuid}-{hostname}-{pid}'.format(
+            uuid=uuid.uuid1().hex,
+            hostname=socket.gethostname(),
+            pid=os.getpid()
         )
 
     @property
@@ -363,6 +374,7 @@ class RedBeatScheduler(Scheduler):
         super(RedBeatScheduler, self).__init__(app, **kwargs)
 
         self.lock_key = lock_key or app.redbeat_conf.lock_key
+        self.lock_token = app.redbeat_conf.lock_token
         self.lock_timeout = (
             lock_timeout
             or app.redbeat_conf.lock_timeout
@@ -511,7 +523,7 @@ def acquire_distributed_beat_lock(sender=None, **kwargs):
     # overwrite redis-py's extend script
     # which will add additional timeout instead of extend to a new timeout
     lock.lua_extend = redis_client.register_script(LUA_EXTEND_TO_SCRIPT)
-    lock.acquire()
+    lock.acquire(token=scheduler.lock_token)
     logger.info('beat: Acquired lock')
 
     scheduler.lock = lock


### PR DESCRIPTION
We run multiple redbeat instances for high availability, and sometimes we find that the service is not behaving as expected, we want to know which server is running, but it's hard to know right now, so we want to use uuid-$hostname-$pid as a lock token to aid troubleshooting.

