### PR TITLE
Add Python 3.11 to the CI testing matrix.

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           pip install flake8 flake8-black flake8-isort

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,10 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Operating System :: OS Independent',
     ],
-    install_requires=['redis>=3.2', 'celery>=4.2', 'python-dateutil', 'tenacity'],
+    install_requires=['redis>=3.2', 'celery>=5.0', 'python-dateutil', 'tenacity'],
     tests_require=['pytest'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps=
     python-dateutil
     redis>=3
     tenacity
+    importlib_metadata<5.0;python_version<"3.8"
 
 commands=
     py.test [] tests --cov=redbeat --junitxml={env:TEST_RESULTS_DIR:.tox/}tox-{envname}.xml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-celery4
-    py{37,38,39,310}-celery5
+    py{37,38,39,310,311}
 
 
 [gh-actions]
@@ -10,11 +9,11 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 deps=
-    celery4: celery>=4.2,<5.0
-    celery5: celery>=5.0
+    celery>=5.0
     fakeredis
     pytest
     pytest-cov


### PR DESCRIPTION
### Changes
Add Python 3.11 to the CI matrix and stop testing the older celery versions