### PR TITLE
Don't reschedule existing static entries on startup

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -393,7 +393,6 @@ class RedBeatScheduler(Scheduler):
             client.sadd(self.app.redbeat_conf.statics_key, *self.app.redbeat_conf.schedule.keys())
 
     def update_from_dict(self, dict_):
-        schedule = self.schedule
         for name, entry in dict_.items():
             try:
                 entry = self._maybe_entry(name, entry)
@@ -402,7 +401,7 @@ class RedBeatScheduler(Scheduler):
                 continue
 
             # don't reschedule the entry if it's already there
-            if entry.name not in schedule or schedule[entry.name] != entry:
+            if entry.name not in self.schedule or self.schedule[entry.name] != entry:
                 entry.save()  # store into redis
                 logger.debug("beat: Stored entry: %s", entry)
 


### PR DESCRIPTION
# Problem

If Redbeat becomes unavailable and then becomes available, it does not execute missed tasks late for static schedule entries.

# Example

If we have a static schedule entry with cron expression 0 * * * * (at minute 0)
And Redbeat becomes unavailable at 1:59pm
And Redbeat becomes available again at 2:01pm
Redbeat should execute the missed task that should have been executed at 2:00pm on the next tick.

However, what happens instead is:
When Redbeat becomes available at 2:01pm, it calls `update_from_dict` which calls `entry.save()` which calls `pipe.zadd(self.app.redbeat_conf.schedule_key, {self.key: self.score})`, which reschedules the task for 3:00pm.

# Solution

Change `update_from_dict` so it does not reschedule existing static entries on startup.