### PR TITLE
fix #238, #208, failure to aquire lock on startup

### DIFF
--- a/tests/basecase.py
+++ b/tests/basecase.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 
 from celery.contrib.testing.app import TestApp
 from celery.schedules import schedule
-from fakeredis import FakeStrictRedis
+from fakeredis import FakeStrictRedis, FakeServer
+from redis.exceptions import ConnectionError
 
 from redbeat.schedulers import RedBeatSchedulerEntry
 
@@ -18,10 +19,11 @@ class AppCase(TestCase):
 
 class RedBeatCase(AppCase):
     def setup(self):
+        self.redis_server = FakeServer()
         self.app.conf.add_defaults(
             {'REDBEAT_KEY_PREFIX': 'rb-tests:', 'redbeat_key_prefix': 'rb-tests:'}
         )
-        self.app.redbeat_redis = FakeStrictRedis(decode_responses=True)
+        self.app.redbeat_redis = FakeStrictRedis(decode_responses=True, server=self.redis_server)
         self.app.redbeat_redis.flushdb()
 
     def create_entry(self, name=None, task=None, s=None, run_every=60, **kwargs):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,9 +8,11 @@ import pytz
 from celery.beat import DEFAULT_MAX_INTERVAL
 from celery.schedules import schedstate, schedule
 from celery.utils.time import maybe_timedelta
+from celery.app import app_or_default
 
+from redis.exceptions import ConnectionError, LockError
 from redbeat import RedBeatScheduler
-from redbeat.schedulers import get_redis
+from redbeat.schedulers import get_redis, acquire_distributed_beat_lock
 from tests.basecase import AppCase, RedBeatCase
 
 
@@ -78,6 +80,10 @@ class test_RedBeatScheduler_schedule(RedBeatSchedulerTestBase):
 
 
 class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
+    def setUp(self):
+        super().setUp()
+        self.s.lock_key = None
+
     def test_empty(self):
         with patch.object(self.s, 'send_task') as send_task:
             sleep = self.s.tick()
@@ -174,6 +180,13 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
 
     def test_lock_timeout(self):
         self.assertEqual(self.s.lock_timeout, self.s.max_interval * 5)
+
+    def test_lock_acquisition_failed_during_startup(self):
+        self.s.lock_key = 'lock-key'
+        self.s.lock = None
+        with self.assertRaises(AttributeError):
+            self.s.tick()
+
 
 
 class NotSentinelRedBeatCase(AppCase):
@@ -358,3 +371,19 @@ class RedBeatLockTimeoutCustomAll(RedBeatCase):
         scheduler = RedBeatScheduler(app=self.app)
         assert self.config_dict['beat_max_loop_interval'] == scheduler.max_interval
         assert self.config_dict['redbeat_lock_timeout'] == scheduler.lock_timeout
+
+
+
+class RedBeatStartupAcquiresLock(RedBeatSchedulerTestBase):
+    def setUp(self):
+        super().setUp()
+        self.sender = Mock(scheduler=self.s)
+
+    def test_acquires_lock(self):
+        acquire_distributed_beat_lock(self.sender)
+        self.assertTrue(self.s.lock.owned())
+
+    def test_connection_error(self):
+        self.redis_server.connected = False
+        with self.assertRaises(ConnectionError):
+            acquire_distributed_beat_lock(self.sender)


### PR DESCRIPTION
In tick() use lock_key rather than lock to decide if we need to hold a lock.  Previously, an exception raised during acquire_distributed_beat_lock() would be silently ignored, allowing multiple instances of Beat to run as lock would be None.