### PR TITLE
Prepare for 2.1.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target_version = ['py36']
+target_version = ['py37']
 skip-string-normalization = true
 
 [tool.isort]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black
-celery>=4.2
+celery>=5.0
 fakeredis>=1.0.3
 python-dateutil
 redis>=3.2

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name="celery-redbeat",
     description="A Celery Beat Scheduler using Redis for persistent storage",
     long_description=long_description,
-    version="2.0.0",
+    version="2.1.0",
     url="https://github.com/sibson/redbeat",
     license="Apache License, Version 2.0",
     author="Marc Sibson",


### PR DESCRIPTION
Small fixes related to the versions consistency. IMHO, ready for PyPi push. Closes #235