### PR TITLE
Replace uses of celery.utils.time

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ redis>=3.2
 tenacity
 twine
 wheel
+backports.zoneinfo>=0.2.1; python_version < "3.9.0"

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,12 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Operating System :: OS Independent',
     ],
-    install_requires=['redis>=3.2', 'celery>=5.0', 'python-dateutil', 'tenacity'],
+    install_requires=[
+        'redis>=3.2',
+        'celery>=5.0',
+        'python-dateutil',
+        'tenacity',
+        'backports.zoneinfo>=0.2.1; python_version < "3.9.0"',
+    ],
     tests_require=['pytest'],
 )

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,13 +1,17 @@
 import json
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest import TestCase
 
 from celery.schedules import crontab, schedule
-from celery.utils.time import FixedOffset, timezone
 from dateutil import rrule as dateutil_rrule
 
 from redbeat.decoder import RedBeatJSONDecoder, RedBeatJSONEncoder
 from redbeat.schedules import rrule
+
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 
 class JSONTestCase(TestCase):
@@ -99,14 +103,14 @@ class RedBeatJSONEncoderTestCase(JSONTestCase):
         self.assertEqual(json.loads(result), expected)
 
     def test_datetime_with_tz(self):
-        dt = self.now(tzinfo=timezone.get_timezone('Asia/Shanghai'))
+        dt = self.now(tzinfo=zoneinfo.ZoneInfo('Asia/Shanghai'))
         result = self.dumps(dt)
 
         expected = self.datetime_as_dict(timezone='Asia/Shanghai', __type__='datetime')
         self.assertEqual(json.loads(result), expected)
 
     def test_datetime_with_fixedoffset(self):
-        dt = self.now(tzinfo=FixedOffset(4 * 60))
+        dt = self.now(tzinfo=timezone(timedelta(hours=4)))
         result = self.dumps(dt)
 
         expected = self.datetime_as_dict(timezone=4 * 60 * 60.0)
@@ -134,7 +138,7 @@ class RedBeatJSONEncoderTestCase(JSONTestCase):
         self.assertEqual(json.loads(result), self.rrule())
 
     def test_rrule_timezone(self):
-        tz = timezone.get_timezone('US/Eastern')
+        tz = zoneinfo.ZoneInfo('US/Eastern')
 
         start1 = datetime(2015, 12, 30, 12, 59, 22, tzinfo=timezone.utc)
         start2 = start1.astimezone(tz)
@@ -209,14 +213,14 @@ class RedBeatJSONDecoderTestCase(JSONTestCase):
         result = self.loads(json.dumps(d))
         d.pop('__type__')
         d.pop('timezone')
-        self.assertEqual(result, datetime(tzinfo=timezone.get_timezone('Asia/Shanghai'), **d))
+        self.assertEqual(result, datetime(tzinfo=zoneinfo.ZoneInfo('Asia/Shanghai'), **d))
 
     def test_datetime_with_fixed_offset(self):
         d = self.datetime_as_dict(__type__='datetime', timezone=5 * 60 * 60)
         result = self.loads(json.dumps(d))
         d.pop('__type__')
         d.pop('timezone')
-        self.assertEqual(result, datetime(tzinfo=FixedOffset(5 * 60), **d))
+        self.assertEqual(result, datetime(tzinfo=timezone(timedelta(hours=5)), **d))
 
     def test_schedule(self):
         d = self.schedule()


### PR DESCRIPTION
The FixedOffset and timezone imports were actually from pytz, which has been deprecated and therefore removed as a celery dependency. Instead, use zoneinfo in Python 3.9+ and backports.zoneinfo in earlier Python 3 versions to look up timezones by name, and use dateutil.timezone.utc and dateutil.timezone(timedelta(...)) to construct timezones that are a fixed offset from UTC.

For background and inspiration, see pganssle/pytz-deprecation-shim, but that is not necessary as a dependency for these uses.

Fixes #244.

------

This passes tests for me but I haven't run extensive experiments yet.