### PR TITLE
Restore wheel publishing

### DIFF
--- a/makefile
+++ b/makefile
@@ -25,7 +25,7 @@ release-tag:
 
 upload: VERSION:=$(shell python setup.py --version)
 upload:
-	python setup.py sdist
+	python setup.py sdist bdist_wheel
 	twine upload $(wildcard dist/celery-*$(VERSION)*)
 
 docs:

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ release-tag:
 upload: VERSION:=$(shell python setup.py --version)
 upload:
 	python setup.py sdist bdist_wheel
-	twine upload $(wildcard dist/celery-*$(VERSION)*)
+	twine upload $(wildcard dist/celery-*$(VERSION)*) $(wildcard dist/celery_*$(VERSION)*)
 
 docs:
 		$(MAKE) -C docs/ html

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ python-dateutil
 redis>=3.2
 tenacity
 twine
+wheel


### PR DESCRIPTION
Seeing that 2.1.0 is nearing release, it'd be great to restore binary distributions if possible, since it's nice to be able to install wheels when possible.