### PR TITLE
test(deps): add pytz which is used in test suites

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ tenacity
 twine
 wheel
 backports.zoneinfo>=0.2.1; python_version < "3.9.0"
+pytz


### PR DESCRIPTION
Was implicitly being installed via Celery, which was removed in
5.3.0 https://github.com/celery/celery/pull/8159

Related to https://github.com/sibson/redbeat/pull/245

Signed-off-by: Mike Fiedler <miketheman@gmail.com>