### PR TITLE
fix: Update the utcoffset func call

### DIFF
--- a/redbeat/decoder.py
+++ b/redbeat/decoder.py
@@ -81,7 +81,7 @@ class RedBeatJSONEncoder(json.JSONEncoder):
             elif hasattr(obj.tzinfo, 'key'):
                 timezone = obj.tzinfo.key
             else:
-                timezone = obj.tzinfo.utcoffset(None).total_seconds()
+                timezone = obj.utcoffset().total_seconds()
 
             return {
                 '__type__': 'datetime',


### PR DESCRIPTION
### FIX: resolving the issue when non UTC format returned None instead of expected total of seconds number.

According to #255 and #251 and my personal observations, line 84 in decoder.py returns None instead of expected number of seconds, which leads to an error during a start of celery. Solution proposed by [hvdklauw](https://github.com/hvdklauw) worked for me. I haven't seen a resolution of this issue, so I'm proposing this change as an inclusion to the project.