### PR TITLE
add ssl support for redis with sentinel

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -118,7 +118,10 @@ def get_redis(app=None):
         retry_period = redis_options.get('retry_period')
         if conf.redis_url.startswith('redis-sentinel') and 'sentinels' in redis_options:
             from redis.sentinel import Sentinel
-
+            ssl_options = {}
+            if isinstance(conf.redis_use_ssl, dict):
+                ssl_options['ssl'] = True
+                ssl_options.update(conf.redis_use_ssl)
             sentinel = Sentinel(
                 redis_options['sentinels'],
                 socket_timeout=redis_options.get('socket_timeout'),
@@ -126,6 +129,7 @@ def get_redis(app=None):
                 db=redis_options.get('db', 0),
                 decode_responses=True,
                 sentinel_kwargs=redis_options.get('sentinel_kwargs'),
+                **ssl_options
             )
             connection = sentinel.master_for(
                 redis_options.get('service_name', 'master'), db=redis_options.get('db', 0)

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -118,10 +118,10 @@ def get_redis(app=None):
         retry_period = redis_options.get('retry_period')
         if conf.redis_url.startswith('redis-sentinel') and 'sentinels' in redis_options:
             from redis.sentinel import Sentinel
-            ssl_options = {}
+            connection_kwargs = {}
             if isinstance(conf.redis_use_ssl, dict):
-                ssl_options['ssl'] = True
-                ssl_options.update(conf.redis_use_ssl)
+                connection_kwargs['ssl'] = True
+                connection_kwargs.update(conf.redis_use_ssl)
             sentinel = Sentinel(
                 redis_options['sentinels'],
                 socket_timeout=redis_options.get('socket_timeout'),
@@ -129,7 +129,7 @@ def get_redis(app=None):
                 db=redis_options.get('db', 0),
                 decode_responses=True,
                 sentinel_kwargs=redis_options.get('sentinel_kwargs'),
-                **ssl_options
+                **connection_kwargs
             )
             connection = sentinel.master_for(
                 redis_options.get('service_name', 'master'), db=redis_options.get('db', 0)


### PR DESCRIPTION
redbeat can already connect to sentinel using tls by setting `sentinel_kwargs` in `redbeat_redis_options` accordingly, e.g.:
```
'sentinel_kwargs': { 'ssl': True, 'ssl_cert_reqs': ssl.CERT_NONE }
```

this will be passed to the Sentinel() constructor and works fine for the connection from redbeat to sentinel.

however, this is only one of the two connections made from redbeat in a redis+sentinel setup...
the next connection which is made to the returned redis master afterwards was always without tls.

to make the connection to redis also use tls, one has to pass the according ssl related [connection_kwargs](https://github.com/redis/redis-py/blob/cc4bc1a544d1030aec1696baef2861064fa8dd1c/redis/sentinel.py#L215) to Sentinel() constructor.

I adapted the code from the encrypted `rediss` case below:
checking if `redis_use_ssl` is defined, and if so, set `ssl` to `True` and inject the parameters provided in `redis_use_ssl` for the connection from redbeat to redis. this way redbeat can be configured to use tls on both, the sentinel AND the redis connection using existing configuration settings and it's working fine for me now...