### PR TITLE
fix: #260 Use redis-py's RedisCluster instead of redis-py-cluster

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -137,10 +137,11 @@ def get_redis(app=None):
             connection = StrictRedis.from_url(conf.redis_url, decode_responses=True, **ssl_options)
         elif conf.redis_url.startswith('redis-cluster'):
             from redis.cluster import RedisCluster
-
-            if not redis_options.get('startup_nodes'):
-                redis_options = {'startup_nodes': [{"host": "localhost", "port": "30001"}]}
-            connection = RedisCluster(decode_responses=True, **redis_options)
+            connection = RedisCluster.from_url(
+                conf.redis_url.replace("redis-cluster://", "redis://"),
+                decode_responses=True, 
+                **redis_options,
+            )
         else:
             connection = StrictRedis.from_url(conf.redis_url, decode_responses=True)
 

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -136,7 +136,7 @@ def get_redis(app=None):
                 ssl_options.update(conf.redis_use_ssl)
             connection = StrictRedis.from_url(conf.redis_url, decode_responses=True, **ssl_options)
         elif conf.redis_url.startswith('redis-cluster'):
-            from rediscluster import RedisCluster
+            from redis.cluster import RedisCluster
 
             if not redis_options.get('startup_nodes'):
                 redis_options = {'startup_nodes': [{"host": "localhost", "port": "30001"}]}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black
 celery>=5.0
 fakeredis>=1.0.3
 python-dateutil
-redis>=3.2
+redis>=4.1
 tenacity
 twine
 wheel

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'Operating System :: OS Independent',
     ],
     install_requires=[
-        'redis>=3.2',
+        'redis>=4.1',
         'celery>=5.0',
         'python-dateutil',
         'tenacity',


### PR DESCRIPTION
Drop support for redis-py < 4.1 and use redis-py's official clustering features