### PR TITLE
Add RedisCluster support

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -116,7 +116,11 @@ def get_redis(app=None):
     if not hasattr(app, 'redbeat_redis') or app.redbeat_redis is None:
         redis_options = conf.redbeat_redis_options
         retry_period = redis_options.get('retry_period')
-        if conf.redis_url.startswith('redis-sentinel') and 'sentinels' in redis_options:
+        if 'cluster' in redis_options:
+            from redis.cluster import RedisCluster
+
+            connection = RedisCluster.from_url(conf.redis_url, **redis_options)
+        elif conf.redis_url.startswith('redis-sentinel') and 'sentinels' in redis_options:
             from redis.sentinel import Sentinel
 
             sentinel = Sentinel(
@@ -205,7 +209,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
         **clsargs,
     ):
         super().__init__(
-            name=name,
+            name=str(name),
             task=task,
             schedule=schedule,
             args=args,

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -116,7 +116,7 @@ def get_redis(app=None):
     if not hasattr(app, 'redbeat_redis') or app.redbeat_redis is None:
         redis_options = conf.redbeat_redis_options
         retry_period = redis_options.get('retry_period')
-        if 'cluster' in redis_options:
+        if redis_options.get('cluster', False):
             from redis.cluster import RedisCluster
 
             connection = RedisCluster.from_url(conf.redis_url, **redis_options)


### PR DESCRIPTION
Redbeat has Sentinel support, but no [Redis cluster support from the main redis-py library](https://redis-py.readthedocs.io/en/stable/clustering.html).

This pull request changes that. To use the mainline redis-py cluster support, just cluster=True to your redbeat options.

I included a very minimal unittest, but have actually used this in a real-world deployment for the past week or so and it's worked well enough. I hope this is helpful to someone else.