### PR TITLE
Debug statement should only log AsyncResult.id if it exists

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -476,7 +476,10 @@ class RedBeatScheduler(Scheduler):
             except Exception as exc:
                 logger.exception('Scheduler: Message Error: %s', exc)
             else:
-                logger.debug('Scheduler: %s sent. id->%s', entry.task, result.id)
+                if result and hasattr(result, 'id'):
+                    logger.debug('Scheduler: %s sent. id->%s', entry.task, result.id)
+                else:
+                    logger.debug('Scheduler: %s sent.', entry.task)
         return next_time_to_run
 
     def tick(self, min=min, **kwargs):


### PR DESCRIPTION
Sometimes there is an error 'NoneType' object has no attribute 'id'

similar problem in celery-beat:
https://github.com/celery/django-celery-beat/issues/658
https://github.com/celery/celery/pull/8428/files