### PR TITLE
Attempt fetch entry from Redis on update_from_dict (#151) 

### DIFF
--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timedelta
+from unittest.mock import patch, PropertyMock, MagicMock
 
 from celery.utils.time import maybe_make_aware
 
@@ -128,3 +129,21 @@ class test_RedBeatEntry(RedBeatCase):
 
         self.assertEqual(score, to_timestamp(expected))
         self.assertEqual(expected, from_timestamp(score))
+
+    def test_generate_key(self) -> None:
+        entry = self.create_entry()
+
+        key = entry.generate_key(app=self.app, name="mock_task_name")
+
+        self.assertEqual(key, "redbeat:mock_task_name")
+
+    @patch.object(RedBeatSchedulerEntry, "generate_key")
+    def test_key(self, mock_generate_key: MagicMock) -> None:
+        entry = self.create_entry()
+
+        key = entry.key
+
+        mock_generate_key.assert_called_once_with(app=self.app, name="test")
+
+        self.assertEqual(key, mock_generate_key.return_value)
+


### PR DESCRIPTION
As mentioned in [this issue ](https://github.com/sibson/redbeat/issues/151), upon restart, ```redbeat``` is not able to pick up the persisted ```last_run_at``` (in Redis), but instead is defaulting to the current datetime for ```last_run_at```.


As a result, tasks end up being scheduled inconsistently between restarts. In larger systems where restarts could be more frequent, this behaviour be impactful.

This PR adds logic to that attempts to fetch an entry from Redis first, using its generated Redis key.
If the key is not found in Redis, only then we can proceed to create a new entry.


Before fix (overdue task):
```
LocalTime -> 2024-11-20 15:05:26
Configuration ->
    . broker -> amqp://guest:**@localhost:5672//
    . loader -> celery.loaders.app.AppLoader
    . scheduler -> redbeat.schedulers.RedBeatScheduler
       . redis -> redis://localhost/
       . lock -> `st:redbeat:lock` 30.00 seconds (30s)
    . logfile -> [stderr]@%WARNING
    . maxinterval -> 5.00 seconds (5s)
{"logger":"celery.beat","level":"info","timestamp":"2024-11-20T20:05:26.209759Z","message":"beat: Starting...","dd.env":"","dd.service":"","dd.version":""}
{"logger":"celery.beat","level":"info","timestamp":"2024-11-20T20:05:26.227691Z","message":"beat: Acquired lock","dd.env":"","dd.service":"","dd.version":""}
{"logger":"celery.beat","level":"info","timestamp":"2024-11-20T20:05:51.297721Z","message":"Scheduler: Sending due task do_something (src.tasks.do_something)","dd.env":"","dd.service":"","dd.version":""}
```
_We can observe the task was sent only 25 seconds after the restart of ```redbeat``` although it was long overdue.
(The delta is 25 seconds)_


After fix (overdue task):
```
LocalTime -> 2024-11-20 15:07:48
Configuration ->
    . broker -> amqp://guest:**@localhost:5672//
    . loader -> celery.loaders.app.AppLoader
    . scheduler -> redbeat.schedulers.RedBeatScheduler
       . redis -> redis://localhost/
       . lock -> `st:redbeat:lock` 30.00 seconds (30s)
    . logfile -> [stderr]@%WARNING
    . maxinterval -> 5.00 seconds (5s)
{"logger":"celery.beat","level":"info","timestamp":"2024-11-20T20:07:48.612525Z","message":"beat: Acquired lock","dd.env":"","dd.service":"","dd.version":""}
{"logger":"celery.beat","level":"info","timestamp":"2024-11-20T20:07:48.620173Z","message":"Scheduler: Sending due task do_something (src.tasks.do_something)","dd.env":"","dd.service":"","dd.version":""}
```
_We can observe that the task was sent as soon as ```redbeat``` was restarted since it was long overdue._