### PR TITLE
fix(RedBeatSchedulerEntry): Update definitions using scheduler information

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -455,7 +455,9 @@ class RedBeatScheduler(Scheduler):
             try:
                 redis_entry = self.Entry.from_key(redis_key, app=self.app)
                 entry = self._maybe_entry(name, entry)
-                entry.last_run_at = redis_entry.last_run_at # update definition while preserving last_run_at
+                entry.last_run_at = (
+                    redis_entry.last_run_at
+                )  # update definition while preserving last_run_at
             except KeyError:
                 try:
                     entry = self._maybe_entry(name, entry)

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -453,14 +453,15 @@ class RedBeatScheduler(Scheduler):
             redis_key = self.Entry.generate_key(self.app, name)
 
             try:
-                entry = self.Entry.from_key(redis_key, app=self.app)
+                redis_entry = self.Entry.from_key(redis_key, app=self.app)
+                entry = self._maybe_entry(name, entry)
+                entry.last_run_at = redis_entry.last_run_at # update definition while preserving last_run_at
             except KeyError:
                 try:
                     entry = self._maybe_entry(name, entry)
                 except Exception as exc:
                     logger.error(ADD_ENTRY_ERROR, name, exc, entry)
                     continue
-
             entry.save()  # store into redis
             logger.debug("beat: Stored entry: %s", entry)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -190,16 +190,18 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
 
 class TestRedBeatSchedulerUpdateFromDict(RedBeatSchedulerTestBase):
     @patch.object(RedBeatSchedulerEntry, "from_key")
-    def test_update_from_dict_fetch_redis_entry(self, mock_from_key: MagicMock) -> None:
+    @patch.object(RedBeatSchedulerEntry, "save")
+    def test_update_from_dict_fetch_redis_entry(self, mock_entry_save: MagicMock, mock_from_key: MagicMock) -> None:
         mock_entry_from_redis_key = mock_from_key.return_value
+        mock_entry_from_redis_key.last_run_at = datetime.now()
 
         self.s.update_from_dict(
             dict_={'task_name': {'task': 'tasks.task_name', 'schedule': timedelta(seconds=30)}}
         )
 
         mock_from_key.assert_called_once_with("rb-tests:task_name", app=self.app)
-
-        mock_entry_from_redis_key.save.assert_called_once()
+    
+        mock_entry_save.assert_called_once()
 
     @patch.object(RedBeatSchedulerEntry, "from_key")
     @patch.object(RedBeatSchedulerEntry, "save")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -191,7 +191,9 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
 class TestRedBeatSchedulerUpdateFromDict(RedBeatSchedulerTestBase):
     @patch.object(RedBeatSchedulerEntry, "from_key")
     @patch.object(RedBeatSchedulerEntry, "save")
-    def test_update_from_dict_fetch_redis_entry(self, mock_entry_save: MagicMock, mock_from_key: MagicMock) -> None:
+    def test_update_from_dict_fetch_redis_entry(
+        self, mock_entry_save: MagicMock, mock_from_key: MagicMock
+    ) -> None:
         mock_entry_from_redis_key = mock_from_key.return_value
         mock_entry_from_redis_key.last_run_at = datetime.now()
 
@@ -200,7 +202,7 @@ class TestRedBeatSchedulerUpdateFromDict(RedBeatSchedulerTestBase):
         )
 
         mock_from_key.assert_called_once_with("rb-tests:task_name", app=self.app)
-    
+
         mock_entry_save.assert_called_once()
 
     @patch.object(RedBeatSchedulerEntry, "from_key")


### PR DESCRIPTION
This PR will update the entry definition found on Redis with the definition from `app.conf.beat_schedule` while preserving the `last_run_at` store on Redis.

The PR ensures that changes to the definitions (e.g. changes to crontab rules or function names) made by developers are reflected on Redis.