### PR TITLE
Fix: support for redis username when using sentinel

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -132,6 +132,14 @@ def get_redis(app=None):
             if isinstance(conf.redis_use_ssl, dict):
                 connection_kwargs['ssl'] = True
                 connection_kwargs.update(conf.redis_use_ssl)
+
+            # username is not included in Sentinel initialization because older versions of
+            # py-redis do not support it. It is supported in redis>=3.4.0, but redbeat
+            # requires redis>=3.2.
+            username = redis_options.get('username')
+            if username:
+                connection_kwargs['username'] = username
+
             sentinel = Sentinel(
                 redis_options['sentinels'],
                 socket_timeout=redis_options.get('socket_timeout'),

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -314,6 +314,15 @@ class SentinelRedBeatCase(AppCase):
         redis_client = get_redis(app=self.app)
         assert 'Sentinel' in str(redis_client.connection_pool)
 
+    def test_sentinel_scheduler_with_username(self):
+        options = deepcopy(self.BROKER_TRANSPORT_OPTIONS)
+        options['username'] = 'acl-user'
+        self.app.conf.update({'BROKER_TRANSPORT_OPTIONS': options})
+        redis_client = get_redis(app=self.app)
+        client_connection_kwargs = redis_client.connection_pool.connection_kwargs
+        assert 'username' in client_connection_kwargs
+        assert client_connection_kwargs['username'] == 'acl-user'
+
 
 class SeparateOptionsForSchedulerCase(AppCase):
     config_dict = {


### PR DESCRIPTION
Redis 6.0 introduced the ACL system which supports username/password authentication.

redbeat does not support using username/password auth for the Redis connection when using Sentinel. 

Currently, the only way to achieve this is to patch the `get_redis` method or perform a hacky workaround in the config:
```py
redbeat_redis_use_ssl = {
    'ssl': False, # Use default behaviour, as if redbeat_redis_use_ssl was not set.
    'username': 'acl-user'
}
```

This PR adds support for the username argument when using sentinel.

The username can be set similar to other arguments:
```py
BROKER_TRANSPORT_OPTIONS = {
    'sentinels': [('192.168.1.1', 26379), ('192.168.1.2', 26379), ('192.168.1.3', 26379)],
    'username': REDIS_USERNAME,
    'password': REDIS_PASSWORD,
    'service_name': 'mymaster',
    'sentinel_kwargs': {
        'username': SENTINEL_USERNAME,
        'password': SENTINEL_PASSWORD,
    }
}
```