### PR TITLE
Add username parameter to Sentinel initialization

### DIFF
--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -143,6 +143,7 @@ def get_redis(app=None):
             sentinel = Sentinel(
                 redis_options['sentinels'],
                 socket_timeout=redis_options.get('socket_timeout'),
+                username=redis_options.get('username'),
                 password=redis_options.get('password'),
                 db=redis_options.get('db', 0),
                 decode_responses=True,


### PR DESCRIPTION

This pull request makes a minor update to the Redis Sentinel connection logic in `redbeat/schedulers.py`. The change adds support for specifying a Redis `username` when connecting to Sentinel, which is important for environments using Redis ACLs.

- Redis Sentinel connection:
  * Updated the `Sentinel` initialization in `get_redis` to include the `username` from `redis_options` if provided.