### PR TITLE
build: make git tags the source of truth for release version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,7 @@
 
 Always release from the `main` branch using the make target, which ensures tests pass before tagging:
 
-    VERSION='M.m.p' make release
+    make release
+
+Version is auto-detected from the "(unreleased)" heading at the top of CHANGES.txt.
+Pass `VERSION='M.m.p'` to override.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,15 @@
 # Release Process
 
-Always release from the `main` branch using the make target, which ensures tests pass before tagging:
+Version is derived from git tags via pbr, not stored in any file. Always
+release from the `main` branch using the make target, which ensures tests
+pass before tagging:
 
     make release
 
-Version is auto-detected from the "(unreleased)" heading at the top of CHANGES.txt.
-Pass `VERSION='M.m.p'` to override.
+By default this releases the next patch version. For a minor/major release,
+first tag the target version so pbr picks it up (this is the one deliberate
+human decision in the process -- pbr can only auto-advance the patch number
+on its own):
+
+    make bump-version VERSION='M.m.p'
+    make release

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: upload release release-test release-tag build version setup lint test unittests docs clean veryclean clean-venv release-check
+.PHONY: upload release release-test release-tag bump-version build version setup lint test unittests docs clean veryclean clean-venv release-check
 
 REQUIREMENTS_TXT=requirements-dev.txt
 
@@ -25,21 +25,34 @@ release-check:
 	test -z "`git status --porcelain`"
 	$(MAKE) test
 
-# VERSION defaults to the version already queued at the top of CHANGES.txt
-# (see the post-release bump below); pass VERSION='M.m.p' to override.
+# VERSION defaults to what pbr derives from git tags (next patch above the
+# last release, or the version targeted by a bump-version pre-release tag);
+# pass VERSION='M.m.p' to override. Git tags are the source of truth, not
+# CHANGES.txt -- use `make bump-version VERSION='M.m.p'` for a minor/major
+# release, since pbr can only auto-advance the patch number on its own.
 release-tag: TODAY:=$(shell date '+%Y-%m-%d')
-release-tag: VERSION:=$(or $(VERSION),$(shell awk 'NR==1 && /\(unreleased\)/ {print $$1}' CHANGES.txt))
+release-tag: VERSION:=$(or $(VERSION),$(shell python setup.py --version 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+'))
 release-tag: NEXT_VERSION=$(shell echo $(VERSION) | awk -F. '{print $$1"."$$2"."$$3+1}')
 release-tag:
-	@test -n "$(VERSION)" || (echo "usage: make release [VERSION='M.m.p'] -- couldn't detect next version from CHANGES.txt" && exit 1)
+	@test -n "$(VERSION)" || (echo "usage: make release [VERSION='M.m.p'] -- couldn't detect version from git tags" && exit 1)
 	@echo "releasing $(VERSION)"
-	sed -i '' -e "s/unreleased/$(TODAY)/" CHANGES.txt
+	sed -i '' -e "1s/.*/$(VERSION) ($(TODAY))/" CHANGES.txt
 	git ci -m"prepare for release of $(VERSION)" CHANGES.txt || git commit -m"prepare for release of $(VERSION)" CHANGES.txt || true
 	git tag -a v$(VERSION) -m"release version $(VERSION)"
 	git push --tags
 	printf "%s\n%s\n%s\n  -\n" "$(NEXT_VERSION) (unreleased)" "---------------------" "$$(cat CHANGES.txt)" > CHANGES.txt
 	git commit -m"bump CHANGES.txt to $(NEXT_VERSION) for post-release development" CHANGES.txt
 	git push
+
+# Force pbr to target a minor/major release instead of auto-advancing the
+# patch number: tags vM.m.p.0a1, a pbr pre-release marker. Every untagged
+# build from here computes as M.m.p.0a<N>.dev<commits> until the real
+# vM.m.p tag lands via `make release`. Deciding to bump minor/major is a
+# human call, so VERSION is required, not inferred.
+bump-version:
+	@test -n "$(VERSION)" || (echo "usage: make bump-version VERSION='M.m.p'" && exit 1)
+	git tag -a v$(VERSION).0a1 -m"target next release version $(VERSION)"
+	git push origin v$(VERSION).0a1
 
 docs:
 	$(MAKE) -C docs/ html

--- a/makefile
+++ b/makefile
@@ -25,20 +25,21 @@ release-check:
 	test -z "`git status --porcelain`"
 	$(MAKE) test
 
+# VERSION defaults to the version already queued at the top of CHANGES.txt
+# (see the post-release bump below); pass VERSION='M.m.p' to override.
 release-tag: TODAY:=$(shell date '+%Y-%m-%d')
+release-tag: VERSION:=$(or $(VERSION),$(shell awk 'NR==1 && /\(unreleased\)/ {print $$1}' CHANGES.txt))
 release-tag: NEXT_VERSION=$(shell echo $(VERSION) | awk -F. '{print $$1"."$$2"."$$3+1}')
 release-tag:
-ifndef VERSION
-	@echo "usage: make release VERSION='M.m.p'" && false
-else
+	@test -n "$(VERSION)" || (echo "usage: make release [VERSION='M.m.p'] -- couldn't detect next version from CHANGES.txt" && exit 1)
+	@echo "releasing $(VERSION)"
 	sed -i '' -e "s/unreleased/$(TODAY)/" CHANGES.txt
 	git ci -m"prepare for release of $(VERSION)" CHANGES.txt || git commit -m"prepare for release of $(VERSION)" CHANGES.txt || true
 	git tag -a v$(VERSION) -m"release version $(VERSION)"
 	git push --tags
-	printf "%s\n%s\n%s\n  -\n" "$(NEXT_VERSION)dev (unreleased)" "---------------------" "$$(cat CHANGES.txt)" > CHANGES.txt
-	git commit -m"bump CHANGES.txt to $(NEXT_VERSION)dev for post-release development" CHANGES.txt
+	printf "%s\n%s\n%s\n  -\n" "$(NEXT_VERSION) (unreleased)" "---------------------" "$$(cat CHANGES.txt)" > CHANGES.txt
+	git commit -m"bump CHANGES.txt to $(NEXT_VERSION) for post-release development" CHANGES.txt
 	git push
-endif
 
 docs:
 	$(MAKE) -C docs/ html


### PR DESCRIPTION
## Summary
Follow-up to #317 (merged before this branch's later commits were pushed).

pbr derives the package version from git tags — this makes git tags the *only* source of truth for it, removing a second hand-maintained copy that could drift:

- `make release` now reads `VERSION` from `python setup.py --version` (pbr's own git-tag-derived version), not from CHANGES.txt. `VERSION='M.m.p'` still works as an explicit override. CHANGES.txt's heading becomes a downstream record — rewritten with the real released version + date at release time — rather than an input.
- New `make bump-version VERSION='M.m.p'` tags `vM.m.p.0a1`, pbr's pre-release marker convention. pbr can only auto-advance the *patch* version on its own between releases; this is the explicit human step for a minor/major release. Every untagged build after it computes as `M.m.p.0a<N>.dev<commits>` until the real `vM.m.p` tag lands via `make release`.
- Updated CLAUDE.md's release docs to describe both commands.

## Test plan
- [x] `make -n release-tag` with no pre-release tag present: derives `VERSION=2.4.1` from git tags (next patch), computes `NEXT_VERSION=2.4.2`
- [x] `make -n bump-version VERSION=4.5.0` prints the expected `git tag`/`git push` for `v4.5.0.0a1`
- [x] End-to-end with a local, unpushed `v4.5.0.0a1` test tag (deleted after): `make -n release-tag` correctly picks up `VERSION=4.5.0`
- [x] Confirmed `v4.5.0dev` (a plausible but wrong tag format) is silently ignored by pbr — the `.0aN` format is required, verified via local test tag before landing on this design

🤖 Generated with [Claude Code](https://claude.com/claude-code)