### PR TITLE
Address review: fix skip-log placement, surface deprecations, expand …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,10 +6,18 @@
     `visibility_timeout` no longer crash beat at startup. RedBeat's own
     options (`retry_period`, `cluster`, ...) are never forwarded on any
     URL type, fixes #319. Options set explicitly via `redbeat_redis_options`
-    still pass through to the client as introduced in 2.4.0.
+    still pass through to the client as introduced in 2.4.0. Note this means
+    keys unknown to redis-py in an explicitly set `redbeat_redis_options`
+    now raise a TypeError at startup, where 2.3.3 silently ignored them on
+    `redis://` and `rediss://` URLs.
+  - bugfix, `get_redis` no longer mutates the options dict in place, so the
+    fallback no longer leaks `decode_responses` (and, on cluster URLs, the
+    normalized `startup_nodes`) into `broker_transport_options`
   - deprecation, falling back to `broker_url` and `broker_transport_options`
     now emits a DeprecationWarning; RedBeat 2.5.0 will require
-    `redbeat_redis_url` and `redbeat_redis_options` to be set explicitly
+    `redbeat_redis_url` and `redbeat_redis_options` to be set explicitly.
+    The message is also logged at warning level, since DeprecationWarning
+    is silenced by default and beat usually runs as a daemon
 
 2.4.1 (2026-07-16)
 ---------------------

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -140,16 +140,13 @@ def get_redis(app=None):
         # options were addressed to redbeat: pass everything except redbeat's
         # own keys through to the client, which validates its own arguments
         connection_options = passthrough_options
+        skipped_options = {}
     else:
         # options inherited from broker_transport_options belong to the broker
-        # and are not forwarded to the client, as before 2.4.0
+        # and are not forwarded to the client, as before 2.4.0; the sentinel
+        # and cluster branches below still consume them
         connection_options = {}
-        if passthrough_options:
-            logger.debug(
-                'beat: not forwarding broker_transport_options to redis: %s; '
-                'set redbeat_redis_options to pass options to the redis client',
-                ', '.join(sorted(passthrough_options)),
-            )
+        skipped_options = passthrough_options
 
     if not hasattr(app, REDBEAT_REDIS_KEY) or getattr(app, REDBEAT_REDIS_KEY) is None:
         if redis_options.get('cluster', False):
@@ -182,6 +179,7 @@ def get_redis(app=None):
             setattr(app, REDBEAT_SENTINEL_KEY, sentinel)
             connection = None
         elif conf.redis_url.startswith('rediss'):
+            _log_skipped_broker_options(skipped_options)
             ssl_options = {'ssl_cert_reqs': ssl.CERT_REQUIRED}
             if isinstance(conf.redis_use_ssl, dict):
                 ssl_options.update(conf.redis_use_ssl)
@@ -198,6 +196,7 @@ def get_redis(app=None):
             passthrough_options.update({"decode_responses": True})
             connection = RedisCluster(startup_nodes=startup_nodes, **passthrough_options)
         else:
+            _log_skipped_broker_options(skipped_options)
             connection_options.update({"decode_responses": True})
             connection = Redis.from_url(conf.redis_url, **connection_options)
 
@@ -214,6 +213,15 @@ def get_redis(app=None):
         _set_redbeat_connect(app, REDBEAT_REDIS_KEY, connection, retry_period)
 
     return getattr(app, REDBEAT_REDIS_KEY)
+
+
+def _log_skipped_broker_options(skipped_options):
+    if skipped_options:
+        logger.debug(
+            'beat: not forwarding broker_transport_options to redis: %s; '
+            'set redbeat_redis_options to pass options to the redis client',
+            ', '.join(sorted(skipped_options)),
+        )
 
 
 def _set_redbeat_connect(app, connect_name, connection, retry_period):
@@ -237,21 +245,25 @@ class RedBeatConfig:
         self.statics_key = self.key_prefix + ':statics'
         self.redis_url = self.either_or('redbeat_redis_url', app.conf['BROKER_URL'])
         if not self.is_key_in_conf('redbeat_redis_url'):
-            warnings.warn(
+            # also log it: DeprecationWarning is silenced by default and beat
+            # usually runs as a daemon, so the warning alone would go unseen
+            message = (
                 'RedBeat will stop falling back to broker_url in version 2.5.0, '
-                'set redbeat_redis_url explicitly',
-                DeprecationWarning,
+                'set redbeat_redis_url explicitly'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            logger.warning(message)
         self.redis_use_ssl = self.either_or('redbeat_redis_use_ssl', app.conf['BROKER_USE_SSL'])
         self.redbeat_redis_options = self.either_or(
             'redbeat_redis_options', app.conf['BROKER_TRANSPORT_OPTIONS']
         )
         if not self.is_key_in_conf('redbeat_redis_options') and self.redbeat_redis_options:
-            warnings.warn(
+            message = (
                 'RedBeat will stop falling back to broker_transport_options in version '
-                '2.5.0, set redbeat_redis_options explicitly',
-                DeprecationWarning,
+                '2.5.0, set redbeat_redis_options explicitly'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            logger.warning(message)
         self.lock_key = self.either_or('redbeat_lock_key', self.key_prefix + ':lock')
         if self.lock_key and not self.lock_key.startswith(self.key_prefix):
             self.lock_key = self.key_prefix + self.lock_key

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -318,6 +318,16 @@ class InheritedClusterOptionsRedBeatCase(AppCase):
         self.assertTrue(kwargs['decode_responses'])
         self.assertEqual(kwargs['startup_nodes'], [{"host": "192.168.1.1", "port": 30001}])
 
+    def test_no_skip_log_when_options_are_forwarded(self):
+        # the "not forwarding" debug log belongs to the redis:// and rediss://
+        # branches only; here the options do reach the client
+        with mock.patch('redis.cluster.RedisCluster'):
+            with mock.patch('redbeat.schedulers.logger') as logger_mock:
+                get_redis(app=self.app)
+
+        for call in logger_mock.debug.call_args_list:
+            self.assertNotIn('not forwarding', call.args[0])
+
 
 class ClusterRedBeatCase(AppCase):
     config_dict = {


### PR DESCRIPTION
…CHANGES

- Emit the 'not forwarding broker_transport_options' debug log only on the redis:// and rediss:// branches where inherited options are actually dropped; it previously also fired on sentinel/cluster paths that do consume them, with a regression test on the inherited cluster path
- Pair each fallback DeprecationWarning with a logger.warning (and stacklevel=2) so daemonized beat users see it despite Python silencing DeprecationWarning by default
- CHANGES.txt: note that explicit redbeat_redis_options with keys unknown to redis-py now fail loudly vs 2.3.3, and that get_redis no longer mutates broker_transport_options in place


Claude-Session: https://claude.ai/code/session_01S4u6bM2DqU6MN8MiDRcUdG