### PR TITLE
test: reproduce #74 — rrule skips the occurrence at dtstart

### DIFF
--- a/tests/test_issue_74.py
+++ b/tests/test_issue_74.py
@@ -1,0 +1,45 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from redbeat.schedules import rrule
+from tests.basecase import RedBeatCase
+
+CREATED_AT = datetime(2017, 12, 9, 21, 19, 58, tzinfo=timezone.utc)
+
+
+class test_Issue_74(RedBeatCase):
+    """An rrule entry skips the occurrence at dtstart, delaying the first run.
+
+    https://github.com/sibson/redbeat/issues/74
+
+    An rrule built without an explicit dtstart defaults it to the creation
+    time (redbeat/schedules.py:53), and celery's ScheduleEntry defaults
+    last_run_at to the same instant. remaining_estimate then asks
+    dateutil for rrule.after(last_run_at) (redbeat/schedules.py:93), which
+    is exclusive, so the occurrence sitting exactly on dtstart is passed
+    over.
+
+    Expected: due at dtstart, the rrule's own first occurrence.
+    Actual:   due one full interval later.
+
+    TRIAGE ARTIFACT -- this file is temporary. When the fix lands, move this
+    test into tests/test_schedules.py, drop the expectedFailure marker,
+    rename it for the behaviour it checks rather than the issue number, and
+    delete this file.
+    """
+
+    @unittest.expectedFailure
+    def test_first_occurrence_is_due_at_dtstart(self):
+        schedule = rrule('MINUTELY', interval=3, count=4, nowfun=lambda: CREATED_AT)
+        self.assertEqual(schedule.dtstart, CREATED_AT)
+
+        entry = self.create_entry(s=schedule)
+
+        self.assertEqual(entry.due_at, CREATED_AT)
+
+    def test_first_occurrence_is_delayed_by_one_interval(self):
+        """Pin the current behaviour, so the fix has to change this line too."""
+        schedule = rrule('MINUTELY', interval=3, count=4, nowfun=lambda: CREATED_AT)
+        entry = self.create_entry(s=schedule)
+
+        self.assertEqual(entry.due_at, CREATED_AT + timedelta(minutes=3))


### PR DESCRIPTION
Adds a failing regression test for #74, reproduced on `main` (`2f96d0a`).

## The mechanism

An `rrule` built without an explicit `dtstart` defaults it to the creation time
(`redbeat/schedules.py:53`), and celery's `ScheduleEntry` defaults `last_run_at`
to the same instant. `remaining_estimate` then asks dateutil for
`rrule.after(last_run_at)` (`redbeat/schedules.py:93`), which is **exclusive** —
so the occurrence sitting exactly on `dtstart` is passed over and the first run
is delayed by a full interval.

For `rrule('MINUTELY', interval=3, count=4)` created at 21:19:58, `due_at` is
21:22:58 rather than 21:19:58:

```
AssertionError: datetime.datetime(2017, 12, 9, 21, 22, 58, tzinfo=datetime.timezone.utc)
             != datetime.datetime(2017, 12, 9, 21, 19, 58, tzinfo=datetime.timezone.utc)
```

This is the first of the two problems @concreted separated out in
https://github.com/sibson/redbeat/issues/74#issuecomment-524460705.

## What's in here

`tests/test_issue_74.py` holds two tests:

- `test_first_occurrence_is_due_at_dtstart` — the bug, marked
  `@unittest.expectedFailure` so CI stays green. `unittest` reports an
  *unexpected success* as a failure, so the day this is fixed the suite says so.
- `test_first_occurrence_is_delayed_by_one_interval` — pins today's behaviour, so
  a fix can't pass the first test without also having to touch this one
  deliberately.

## At fix time

This is a triage artifact, not a permanent home. Whoever fixes this should move
the first test into `tests/test_schedules.py`, drop the `expectedFailure`
marker, rename it for the behaviour it checks rather than the issue number,
delete `test_first_occurrence_is_delayed_by_one_interval`, and delete this file.
The same note is in the class docstring.

Not addressed here: the second problem in #74 — an rrule whose occurrences are
*all* in the past is never scheduled at all (`due_at` is `None`, `score` is
`-1`). That one is a design question about whether missed occurrences should
fire, not a clear defect, so I left it for the maintainer.