### PR TITLE
Document how to list all stored schedule entries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 2.4.3 (unreleased)
 ---------------------
+  - doc, document how to list every stored entry, and note that
+    `RedBeatScheduler.schedule` is a due-window query rather than the whole
+    schedule, fixes #155
 2.4.2 (2026-07-27)
 ---------------------
   - bugfix, restore the pre-2.4.0 handling of options inherited from

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -28,6 +28,34 @@ a key of ``<redbeat_key_prefix>:task-name``. It should contain a single key
 .. _`CELERYBEAT_SCHEDULE`: http://docs.celeryproject.org/en/3.1/userguide/periodic-tasks.html#beat-entries
 .. _`beat_schedule`: http://docs.celeryproject.org/en/4.0/userguide/periodic-tasks.html#beat-entries
 
+Listing Tasks
+~~~~~~~~~~~~~
+RedBeat keeps every saved entry in a sorted set at ``<redbeat_key_prefix>:schedule``,
+scored by the next time each task is due. To enumerate the whole schedule, read the
+keys out of that set and load each one with ``RedBeatSchedulerEntry.from_key()``::
+
+    from redbeat import RedBeatSchedulerEntry
+    from redbeat.schedulers import ensure_conf, get_redis
+
+    conf = ensure_conf(app)
+    keys = get_redis(app).zrange(conf.schedule_key, 0, -1)
+    entries = [RedBeatSchedulerEntry.from_key(key, app=app) for key in keys]
+
+A single entry can be loaded by name::
+
+    key = RedBeatSchedulerEntry.generate_key(app, 'task-name')
+    entry = RedBeatSchedulerEntry.from_key(key, app=app)
+
+``from_key()`` raises ``KeyError`` if no such task is stored.
+
+.. note::
+
+    ``RedBeatScheduler.schedule`` is **not** an accessor for the stored schedule. It
+    is the per-tick query Beat uses to find work: it returns only the tasks due now,
+    plus at most one task due within the next ``max_interval`` so Beat can size its
+    sleep. Called outside a running Beat it will usually return ``{}``, even when the
+    schedule holds many tasks. Use the sorted set walk above to list everything.
+
 Interval
 ~~~~~~~~
 An interval task is defined with the JSON like::

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -17,6 +17,7 @@ from redbeat.schedulers import (
     RedBeatSchedulerEntry,
     RetryingConnection,
     acquire_distributed_beat_lock,
+    ensure_conf,
     get_redis,
 )
 from tests.basecase import AppCase, RedBeatCase
@@ -83,6 +84,31 @@ class test_RedBeatScheduler_schedule(RedBeatSchedulerTestBase):
 
         self.assertNotIn(up_next2.name, schedule)
         self.assertNotIn(later.name, schedule)
+
+    def test_stored_entries_are_listable_via_the_schedule_key(self):
+        # the recipe documented in docs/tasks.rst: .schedule is a due-window
+        # query, walking the sorted set is how you enumerate every entry
+        due = self.create_entry(name='due', s=due_now).save()
+        later = self.create_entry(name='later', s=self.due_later).save()
+
+        self.assertNotIn(later.name, self.s.schedule)
+
+        conf = ensure_conf(self.app)
+        keys = get_redis(self.app).zrange(conf.schedule_key, 0, -1)
+        entries = [RedBeatSchedulerEntry.from_key(key, app=self.app) for key in keys]
+
+        self.assertEqual(sorted(e.name for e in entries), [due.name, later.name])
+
+    def test_entry_is_loadable_by_generated_key(self):
+        entry = self.create_entry(name='findme', s=due_now).save()
+
+        key = RedBeatSchedulerEntry.generate_key(self.app, 'findme')
+        self.assertEqual(RedBeatSchedulerEntry.from_key(key, app=self.app).key, entry.key)
+
+        with self.assertRaises(KeyError):
+            RedBeatSchedulerEntry.from_key(
+                RedBeatSchedulerEntry.generate_key(self.app, 'nosuchtask'), app=self.app
+            )
 
 
 class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):


### PR DESCRIPTION
Adds documentation and tests for enumerating all stored RedBeat schedule entries, clarifying that `RedBeatScheduler.schedule` is a due-window query rather than a complete schedule view.

## Changes

- **Documentation**: Added "Listing Tasks" section to `docs/tasks.rst` with:
  - Recipe for walking the sorted set at `<redbeat_key_prefix>:schedule` to enumerate all entries
  - Example of loading a single entry by name using `generate_key()` and `from_key()`
  - Note clarifying that `RedBeatScheduler.schedule` returns only tasks due now plus one future task, not the complete schedule
  
- **Tests**: Added two test cases to `tests/test_scheduler.py`:
  - `test_stored_entries_are_listable_via_the_schedule_key`: Verifies the documented recipe works correctly
  - `test_entry_is_loadable_by_generated_key`: Verifies single entry lookup and `KeyError` handling for missing tasks

- **Changelog**: Updated `CHANGES.txt` with entry for this documentation fix (fixes #155)

https://claude.ai/code/session_01XQf66EquRJvEHMGZu5CQhH