### PR TITLE
bugfix: stop pinning beat dispatch to a single producer connection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,12 @@
 2.4.3 (unreleased)
 ---------------------
+  - bugfix, `_maybe_due_kwargs` is no longer a `cached_property`, so it no
+    longer pins beat's dispatch to a single kombu producer/connection for the
+    life of the process. Previously, once that connection broke (an idle
+    connection reaped by the broker, a proxy failover, ...), every subsequent
+    publish failed silently -- `maybe_due` only logs the exception -- while
+    RedBeat's own bookkeeping (via a separate redis-py client) kept advancing,
+    so the schedule looked healthy throughout
   - doc, document how to list every stored entry, and note that
     `RedBeatScheduler.schedule` is a due-window query rather than the whole
     schedule, fixes #155

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -16,7 +16,6 @@ from celery.beat import DEFAULT_MAX_INTERVAL, ScheduleEntry, Scheduler
 from celery.signals import beat_init
 from celery.utils.log import get_logger
 from celery.utils.time import humanize_seconds
-from kombu.utils.objects import cached_property
 from kombu.utils.url import maybe_sanitize_url
 from redis import Redis
 from redis.sentinel import MasterNotFoundError, Sentinel
@@ -624,7 +623,7 @@ class RedBeatScheduler(Scheduler):
             )
         return '\n'.join(info)
 
-    @cached_property
+    @property
     def _maybe_due_kwargs(self):
         """handle rename of publisher to producer"""
         return {'producer': self.producer}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,7 +3,7 @@ import unittest
 from copy import deepcopy
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytz
 from celery.beat import DEFAULT_MAX_INTERVAL
@@ -194,6 +194,21 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
             send_task.assert_called_with(e.task, e.args, e.kwargs, **self.s._maybe_due_kwargs)
 
         self.assertEqual(sleep, 1.0)
+
+    def test_maybe_due_kwargs_reflects_a_fresh_producer_each_tick(self):
+        # _maybe_due_kwargs must not be a cached_property: `producer` (from
+        # celery.beat.Scheduler) is itself a cached_property wrapping a single
+        # connection, and if beat pins that producer for the life of the
+        # process, a connection that later breaks fails every dispatch
+        # forever while RedBeat's own bookkeeping keeps advancing.
+        producers = [Mock(name='first'), Mock(name='second')]
+        with patch.object(type(self.s), 'producer', new_callable=PropertyMock) as producer:
+            producer.side_effect = producers
+            first = self.s._maybe_due_kwargs['producer']
+            second = self.s._maybe_due_kwargs['producer']
+
+        self.assertIs(first, producers[0])
+        self.assertIs(second, producers[1])
 
     def test_old_static_entries_are_removed(self):
         redis = self.app.redbeat_redis


### PR DESCRIPTION
## What & why

`_maybe_due_kwargs` (`redbeat/schedulers.py`) was a `cached_property` returning
`{'producer': self.producer}`. `self.producer` is itself a `cached_property`
on `celery.beat.Scheduler`, wrapping a single kombu connection
(`Producer(self._ensure_connected(), ...)`).

Caching `_maybe_due_kwargs` on top of that meant a beat process resolves one
producer/connection on its first tick and reuses it for every dispatch for
the rest of the process's life — nothing ever refreshes it.

If that connection ever breaks (an idle connection reaped by the broker, a
proxy failover, a TCP reset), every subsequent publish fails. That failure is
invisible: `celery.beat.Scheduler.apply_async` reserves/persists
`last_run_at` / `total_run_count` / the schedule ZSET score via `reserve()`
*before* attempting the publish, and RedBeat's `maybe_due` catches the publish
exception and only logs it:

```python
try:
    result = self.apply_async(entry, **kwargs)
except Exception as exc:
    logger.exception('Scheduler: Message Error: %s', exc)
```

RedBeat's own bookkeeping runs over a separate redis-py client that
reconnects independently, so Redis-side signals (`total_run_count`,
`last_run_at`, the ZSET score, lock TTL) keep advancing normally and look
identical whether the publish succeeded or is failing on every tick. The only
symptom is that tasks silently stop reaching workers.

## Fix

Make `_maybe_due_kwargs` a plain `@property` instead of a `cached_property`.
This is the only change needed — it stops pinning the resolved producer, so
each tick re-reads `self.producer`. (`self.producer` itself is still a
`cached_property` from `celery.beat.Scheduler`, matching upstream Celery's
own reuse-a-producer behavior for a healthy connection; this fix only removes
RedBeat's own extra layer of caching on top of it.)

## Test plan

- Added `test_maybe_due_kwargs_reflects_a_fresh_producer_each_tick` to
  `tests/test_scheduler.py`, which patches `producer` to return different
  mocks on successive accesses and asserts `_maybe_due_kwargs['producer']`
  reflects each one. Verified it fails against the pre-fix `cached_property`
  and passes with the fix.
- `make lint` and `make test` (90 tests) both pass.

## Heads-up for reviewers

No behavior change for the common case where the connection stays healthy —
`self.producer` is unaffected and still cached at the `celery.beat.Scheduler`
level. This only removes the extra pinning RedBeat added on top, so a broken
connection can heal on the next tick instead of failing for the life of the
process.