### PR TITLE
doc: Redis and Valkey server support policy; redis-py as the supported client

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 2.4.3 (unreleased)
 ---------------------
+  - doc, document that RedBeat supports both Redis and Valkey servers, with
+    intent to maintain both absent major upstream behaviour changes, #301
   - doc, document how to list every stored entry, and note that
     `RedBeatScheduler.schedule` is a due-window query rather than the whole
     schedule, fixes #155

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 2.4.3 (unreleased)
 ---------------------
   - doc, document that RedBeat supports both Redis and Valkey servers, with
-    intent to maintain both absent major upstream behaviour changes, #301
+    intent to maintain both absent major upstream behaviour changes, and
+    that redis-py is the only supported client library, #301
   - doc, document how to list every stored entry, and note that
     `RedBeatScheduler.schedule` is a due-window query rather than the whole
     schedule, fixes #155

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,18 @@ To disable this feature, set:
 
 More details available on `Read the Docs <https://redbeat.readthedocs.io/en/latest/>`_
 
+Server compatibility
+--------------------
+
+RedBeat works with both `Redis <https://redis.io/>`_ and
+`Valkey <https://valkey.io/>`_ servers -- point ``redbeat_redis_url`` at
+either. We intend to maintain support for both for as long as neither
+introduces a major behaviour change RedBeat depends on, or an
+incompatibility upstream.
+
+RedBeat uses the `redis-py <https://github.com/redis/redis-py>`_ client to
+talk to either server.
+
 Development
 --------------
 RedBeat is available on `GitHub <https://github.com/sibson/redbeat>`_

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ introduces a major behaviour change RedBeat depends on, or an
 incompatibility upstream.
 
 RedBeat uses the `redis-py <https://github.com/redis/redis-py>`_ client to
-talk to either server.
+talk to either server; it is the only supported client library.
 
 Development
 --------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -7,7 +7,7 @@ You can add any of the following parameters to your Celery configuration:
 ~~~~~~~~~~~~~~~~~~~~~
 
 URL to redis server used to store the schedule, defaults to value of
-`broker_url`_.
+`broker_url`_. Both Redis and Valkey servers are supported.
 
 .. deprecated:: 2.4.2
    The fallback to `broker_url`_ is deprecated and will be removed in


### PR DESCRIPTION
Documents the compatibility stance discussed on #301:

- **Servers**: RedBeat supports both Redis and Valkey — point `redbeat_redis_url` at either — with intent to maintain both for as long as neither introduces a major behaviour change RedBeat depends on, or an upstream incompatibility.
- **Client**: redis-py is the only supported client library, serving both servers.

The claim is backed by a live 2×2 matrix run recorded on #301 (redis-py 8.1.0 / valkey-py 6.1.1 × Redis 7.0.15 / Valkey 7.2.12): RedBeat's full scheduling and locking paths — including the custom Lua extend script via `EVALSHA` — passed in all four cells.

Changes:
- `README.rst`: new "Server compatibility" section (flows into the docs site via `docs/intro.rst`)
- `docs/config.rst`: one-line note under `redbeat_redis_url`
- `CHANGES.txt`: entry under 2.4.3 (unreleased), refs #301

`make lint` and `make test` pass (89 tests, 2 skipped).

A follow-up worth considering separately: a CI job running a smoke suite against `redis:7` and `valkey:8` service containers, so this doc claim stays continuously tested rather than verified once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ByLcLXcYwTdaxU55JcUrG)_