### PR TITLE
bugfix: log missing-hash schedule entries at error, not warning

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 2.4.3 (unreleased)
 ---------------------
+  - bugfix, raise the log level from warning to error when a scheduled
+    entry's hash is missing (e.g. evicted by Redis) and the entry is
+    dropped from the schedule, so operators notice instead of the loss
+    passing silently, fixes #291
   - doc, document that RedBeat supports both Redis and Valkey servers, with
     intent to maintain both absent major upstream behaviour changes, and
     that redis-py is the only supported client library, #301

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -565,7 +565,7 @@ class RedBeatScheduler(Scheduler):
             try:
                 entry = self.Entry.from_key(key, app=self.app)
             except KeyError:
-                logger.warning('beat: Failed to load %s, removing', key)
+                logger.error('beat: Failed to load %s, removing', key)
                 client.zrem(self.app.redbeat_conf.schedule_key, key)
                 continue
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -99,6 +99,21 @@ class test_RedBeatScheduler_schedule(RedBeatSchedulerTestBase):
 
         self.assertEqual(sorted(e.name for e in entries), [due.name, later.name])
 
+    def test_missing_hash_for_zset_member_logs_error_and_is_removed(self):
+        # simulate Redis evicting the hash while the zset member survives
+        due = self.create_entry(name='due', s=due_now).save()
+        conf = ensure_conf(self.app)
+        get_redis(self.app).delete(due.key)
+
+        with self.assertLogs('celery.beat', level='ERROR') as cm:
+            schedule = self.s.schedule
+
+        self.assertNotIn(due.name, schedule)
+        self.assertTrue(any('Failed to load' in message for message in cm.output))
+
+        remaining = get_redis(self.app).zrange(conf.schedule_key, 0, -1)
+        self.assertNotIn(due.key, remaining)
+
     def test_entry_is_loadable_by_generated_key(self):
         entry = self.create_entry(name='findme', s=due_now).save()
 


### PR DESCRIPTION
## What & why

When `RedBeatScheduler.schedule` finds a key in the schedule ZSET whose hash is
gone (evicted by Redis, deleted out from under beat), it drops the entry from
the schedule and logs at `warning`. The entry silently stops running from that
point on — an operator watching at the default log level has no strong signal
that a scheduled task just disappeared.

## Fix

Raise that one log call from `logger.warning` to `logger.error`. The removal
behaviour is unchanged; only the level moves.

## Test plan

- Added `test_missing_hash_for_zset_member_logs_error_and_is_removed` to
  `tests/test_scheduler.py`: saves an entry, deletes its hash directly to
  simulate eviction, and asserts the entry is dropped from both the schedule
  and the ZSET while logging at `ERROR`.
- `make test` passes (90 tests).

Closes #291

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAnuwguSXH8EJ78MYTEWjH)_