### PR TITLE
bugfix: due_at adds the remaining delta to now, not to last_run_at

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,10 @@
 2.4.3 (unreleased)
 ---------------------
   - bugfix, `RedBeatSchedulerEntry.due_at` added the remaining-time delta to
-    `last_run_at` instead of to the current time, so it (and the ZSET score
-    derived from it) understated how soon a task was due by exactly the age
-    of `last_run_at`, fixes #210
+    `last_run_at` instead of to the current time, so `due_at` (and the ZSET
+    score derived from it) reported a time earlier than the actual next
+    occurrence by the age of `last_run_at`, causing entries to be re-read
+    from Redis on every tick until they next ran, fixes #210
   - doc, document that RedBeat supports both Redis and Valkey servers, with
     intent to maintain both absent major upstream behaviour changes, and
     that redis-py is the only supported client library, #301

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 2.4.3 (unreleased)
 ---------------------
+  - bugfix, `RedBeatSchedulerEntry.due_at` added the remaining-time delta to
+    `last_run_at` instead of to the current time, so it (and the ZSET score
+    derived from it) understated how soon a task was due by exactly the age
+    of `last_run_at`, fixes #210
   - doc, document that RedBeat supports both Redis and Valkey servers, with
     intent to maintain both absent major upstream behaviour changes, and
     that redis-py is the only supported client library, #301

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -387,7 +387,7 @@ class RedBeatSchedulerEntry(ScheduleEntry):
         if delta.total_seconds() < 0:
             return self._default_now()
 
-        return self.last_run_at + delta
+        return self._default_now() + delta
 
     @property
     def key(self):

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -97,16 +97,19 @@ class test_RedBeatEntry(RedBeatCase):
         self.assertLess(due_at, after)
 
     def test_due_at(self):
-        # pin the clock so the assertion isn't at the mercy of how much
-        # wall-clock time elapses between the two `now()` calls below.
-        now = datetime(2021, 9, 1, 0, 0, 0, tzinfo=timezone.utc)
+        # pin the clock, and give last_run_at some age relative to it, so the
+        # old (buggy) and new arithmetic actually disagree here: adding the
+        # remaining delta to last_run_at instead of to now would land 20s
+        # early, at now + 20s rather than the correct now + 40s.
+        now = datetime(2021, 9, 1, 0, 0, 20, tzinfo=timezone.utc)
+        last_run_at = datetime(2021, 9, 1, 0, 0, 0, tzinfo=timezone.utc)
         run_every = 60
         s = schedule(run_every=run_every, nowfun=lambda: now)
-        entry = self.create_entry(s=s, last_run_at=now)
+        entry = self.create_entry(s=s, last_run_at=last_run_at)
 
         due_at = entry.due_at
 
-        self.assertEqual(due_at, now + timedelta(seconds=run_every))
+        self.assertEqual(due_at, now + timedelta(seconds=40))
 
     def test_due_at_remaining_estimate_from_now(self):
         # last ran at midnight, it's now 00:45, task runs hourly -> due at 1am.

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,7 +1,8 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+from celery.schedules import schedule
 from celery.utils.time import maybe_make_aware
 
 from redbeat import RedBeatSchedulerEntry
@@ -96,15 +97,28 @@ class test_RedBeatEntry(RedBeatCase):
         self.assertLess(due_at, after)
 
     def test_due_at(self):
-        entry = self.create_entry()
+        # pin the clock so the assertion isn't at the mercy of how much
+        # wall-clock time elapses between the two `now()` calls below.
+        now = datetime(2021, 9, 1, 0, 0, 0, tzinfo=timezone.utc)
+        run_every = 60
+        s = schedule(run_every=run_every, nowfun=lambda: now)
+        entry = self.create_entry(s=s, last_run_at=now)
 
-        now = entry._default_now()
-
-        entry.last_run_at = now
         due_at = entry.due_at
 
-        self.assertLess(now, due_at)
-        self.assertLess(due_at, now + entry.schedule.run_every)
+        self.assertEqual(due_at, now + timedelta(seconds=run_every))
+
+    def test_due_at_remaining_estimate_from_now(self):
+        # last ran at midnight, it's now 00:45, task runs hourly -> due at 1am.
+        # remaining_estimate() measures the delta from *now*, not from
+        # last_run_at, so due_at must add that delta to now as well.
+        now = datetime(2021, 9, 1, 0, 45, 0, tzinfo=timezone.utc)
+        last_run_at = datetime(2021, 9, 1, 0, 0, 0, tzinfo=timezone.utc)
+        s = schedule(run_every=3600, nowfun=lambda: now)
+
+        entry = self.create_entry(s=s, last_run_at=last_run_at)
+
+        self.assertEqual(entry.due_at, datetime(2021, 9, 1, 1, 0, 0, tzinfo=timezone.utc))
 
     def test_due_at_overdue(self):
         last_run_at = self.app.now() - timedelta(hours=10)

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -97,10 +97,8 @@ class test_RedBeatEntry(RedBeatCase):
         self.assertLess(due_at, after)
 
     def test_due_at(self):
-        # pin the clock, and give last_run_at some age relative to it, so the
-        # old (buggy) and new arithmetic actually disagree here: adding the
-        # remaining delta to last_run_at instead of to now would land 20s
-        # early, at now + 20s rather than the correct now + 40s.
+        # age last_run_at against a pinned clock so the old arithmetic
+        # disagrees: it would land at now + 20s, not now + 40s
         now = datetime(2021, 9, 1, 0, 0, 20, tzinfo=timezone.utc)
         last_run_at = datetime(2021, 9, 1, 0, 0, 0, tzinfo=timezone.utc)
         run_every = 60
@@ -112,9 +110,7 @@ class test_RedBeatEntry(RedBeatCase):
         self.assertEqual(due_at, now + timedelta(seconds=40))
 
     def test_due_at_remaining_estimate_from_now(self):
-        # last ran at midnight, it's now 00:45, task runs hourly -> due at 1am.
-        # remaining_estimate() measures the delta from *now*, not from
-        # last_run_at, so due_at must add that delta to now as well.
+        # last ran at midnight, now 00:45, hourly -> due at 1am
         now = datetime(2021, 9, 1, 0, 45, 0, tzinfo=timezone.utc)
         last_run_at = datetime(2021, 9, 1, 0, 0, 0, tzinfo=timezone.utc)
         s = schedule(run_every=3600, nowfun=lambda: now)


### PR DESCRIPTION
## What & why

`RedBeatSchedulerEntry.due_at` computed `self.last_run_at + delta`, but `delta`
comes from `remaining_estimate()`, which measures time remaining **from now**,
not from `last_run_at`. Adding a from-now delta to a past timestamp lands early
by exactly the age of `last_run_at`.

Since the ZSET score is derived from `due_at`, the entry sorts as due sooner
than it really is and gets re-read from Redis on every tick until it actually
runs.

## Fix

```python
-return self.last_run_at + delta
+return self._default_now() + delta
```

## Test plan

- `test_due_at` now pins the clock and gives `last_run_at` a 20s age, so the
  old and new arithmetic genuinely disagree (old: now+20s, correct: now+40s).
  The previous assertions bracketed `due_at` loosely enough to pass either way.
- Added `test_due_at_remaining_estimate_from_now`: last ran at midnight, now
  00:45, hourly schedule → due at 01:00 exactly.
- `make test` passes (90 tests).

## Relationship to #308

This supersedes #308, which makes the same one-line change but also hand-edits
the `version`/`[pbr] version` fields in `setup.cfg` (version is derived from git
tags via pbr, so those edits are wrong), leaves a stray `-` bullet at the end of
`CHANGES.txt`, and asserts with `assertAlmostEqual(..., delta=1)` against an
unpinned clock rather than pinning it.

Closes #210
Closes #307

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAnuwguSXH8EJ78MYTEWjH)_