### PR TITLE
feature: accept sentinel:// and redis+sentinel:// as scheme aliases

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,12 @@
 2.4.3 (unreleased)
 ---------------------
-  - feature, accept celery's `sentinel://` and kombu's `redis+sentinel://` as
-    scheme aliases for `redis-sentinel://` in `redbeat_redis_url`, so the same
-    broker DSN can be reused for `redbeat_redis_url`, fixes #199
+  - bugfix, accept celery's `sentinel://` and kombu's `redis+sentinel://` as
+    scheme aliases for `redis-sentinel://` in `redbeat_redis_url`. This only
+    helps if `redbeat_redis_options` (or `broker_transport_options`) already
+    sets `sentinels`; a purely celery-native sentinel config (`master_name`
+    in `broker_transport_options`, hosts derived from a `;`-joined
+    `sentinel://` URL) still falls through to `Redis.from_url` and still
+    raises, fixes #199
   - doc, document that RedBeat supports both Redis and Valkey servers, with
     intent to maintain both absent major upstream behaviour changes, and
     that redis-py is the only supported client library, #301

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 2.4.3 (unreleased)
 ---------------------
+  - feature, accept celery's `sentinel://` and kombu's `redis+sentinel://` as
+    scheme aliases for `redis-sentinel://` in `redbeat_redis_url`, so the same
+    broker DSN can be reused for `redbeat_redis_url`, fixes #199
   - doc, document that RedBeat supports both Redis and Valkey servers, with
     intent to maintain both absent major upstream behaviour changes, and
     that redis-py is the only supported client library, #301

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -93,7 +93,16 @@ configuration syntax is inspired from `celery-redis-sentinel
 
 Some notes about the configuration:
 
-* note the use of ``redis-sentinel`` schema within the URL.
+* note the use of ``redis-sentinel`` schema within the URL. ``sentinel://``
+  (celery's native broker scheme) and ``redis+sentinel://`` (kombu's) are
+  also accepted as aliases here, but only as a scheme match: RedBeat still
+  requires the ``sentinels`` setting shown above (and ignores
+  ``master_name``/``service_name`` derivation from the URL). A
+  ``broker_url`` such as ``sentinel://h1:26379;sentinel://h2:26379`` with
+  ``broker_transport_options = {'master_name': 'mymaster'}`` -- a purely
+  celery-native sentinel config with no explicit ``sentinels`` list -- is
+  not enough on its own; you still need to set ``REDBEAT_REDIS_OPTIONS``
+  (or ``BROKER_TRANSPORT_OPTIONS``) with ``sentinels`` as above.
 
 * hostname and port are ignored within the actual URL. Sentinel uses
   the ``sentinels`` setting to create a ``Sentinel()`` instead of

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -153,9 +153,10 @@ def get_redis(app=None):
             from redis.cluster import RedisCluster
 
             connection = RedisCluster.from_url(conf.redis_url, **passthrough_options)
-        elif conf.redis_url.startswith(
-            ('redis-sentinel', 'sentinel://', 'redis+sentinel://')
-        ) and 'sentinels' in redis_options:
+        elif (
+            conf.redis_url.startswith(('redis-sentinel', 'sentinel://', 'redis+sentinel://'))
+            and 'sentinels' in redis_options
+        ):
             connection_kwargs = {}
             if isinstance(conf.redis_use_ssl, dict):
                 connection_kwargs['ssl'] = True

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -153,7 +153,9 @@ def get_redis(app=None):
             from redis.cluster import RedisCluster
 
             connection = RedisCluster.from_url(conf.redis_url, **passthrough_options)
-        elif conf.redis_url.startswith('redis-sentinel') and 'sentinels' in redis_options:
+        elif conf.redis_url.startswith(
+            ('redis-sentinel', 'sentinel://', 'redis+sentinel://')
+        ) and 'sentinels' in redis_options:
             connection_kwargs = {}
             if isinstance(conf.redis_use_ssl, dict):
                 connection_kwargs['ssl'] = True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -447,6 +447,45 @@ class SentinelRedBeatCase(AppCase):
         assert client_connection_kwargs.get('username') == 'acl-user'
 
 
+class SentinelSchemeAliasRedBeatCase(AppCase):
+    """Celery natively supports `sentinel://` and kombu supports `redis+sentinel://`
+    as broker URL schemes for Redis Sentinel; redbeat should accept the same
+    aliases for redbeat_redis_url so the same DSN can be reused (#199)."""
+
+    config_dict = {
+        'REDBEAT_KEY_PREFIX': 'rb-tests:',
+        'redbeat_key_prefix': 'rb-tests:',
+    }
+    BROKER_TRANSPORT_OPTIONS = {
+        'sentinels': [('192.168.1.1', 26379), ('192.168.1.2', 26379), ('192.168.1.3', 26379)],
+        'service_name': 'master',
+        'socket_timeout': 0.1,
+    }
+
+    def setup(self):  # celery3
+        self.app.conf.add_defaults(deepcopy(self.config_dict))
+
+    def test_sentinel_scheme_alias(self):
+        self.app.conf.update(
+            {
+                'BROKER_URL': 'sentinel://redis-sentinel:26379/0',
+                'BROKER_TRANSPORT_OPTIONS': self.BROKER_TRANSPORT_OPTIONS,
+            }
+        )
+        redis_client = get_redis(app=self.app)
+        assert 'Sentinel' in str(redis_client.connection_pool)
+
+    def test_redis_plus_sentinel_scheme_alias(self):
+        self.app.conf.update(
+            {
+                'BROKER_URL': 'redis+sentinel://redis-sentinel:26379/0',
+                'BROKER_TRANSPORT_OPTIONS': self.BROKER_TRANSPORT_OPTIONS,
+            }
+        )
+        redis_client = get_redis(app=self.app)
+        assert 'Sentinel' in str(redis_client.connection_pool)
+
+
 class SeparateOptionsForSchedulerCase(AppCase):
     config_dict = {
         'REDBEAT_KEY_PREFIX': 'rb-tests:',

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -485,6 +485,21 @@ class SentinelSchemeAliasRedBeatCase(AppCase):
         redis_client = get_redis(app=self.app)
         assert 'Sentinel' in str(redis_client.connection_pool)
 
+    def test_celery_native_sentinel_config_without_sentinels_option_still_fails(self):
+        """A purely celery-native sentinel config -- multiple `;`-joined
+        sentinel:// hosts in broker_url and `master_name` in
+        broker_transport_options, with no redbeat-shaped `sentinels` list --
+        is still not accepted: the scheme alias only helps once `sentinels`
+        is set explicitly (#199)."""
+        self.app.conf.update(
+            {
+                'BROKER_URL': 'sentinel://h1:26379;sentinel://h2:26379',
+                'BROKER_TRANSPORT_OPTIONS': {'master_name': 'mymaster'},
+            }
+        )
+        with self.assertRaises(ValueError):
+            get_redis(app=self.app)
+
 
 class SeparateOptionsForSchedulerCase(AppCase):
     config_dict = {


### PR DESCRIPTION
## What & why

`get_redis()` only routed to the Sentinel branch when `redbeat_redis_url`
started with `redis-sentinel`. Celery's own native sentinel scheme is
`sentinel://` and kombu's is `redis+sentinel://`, so a user who reuses their
broker DSN for `redbeat_redis_url` falls through to `Redis.from_url` and gets an
unhelpful failure.

## Fix

Match all three scheme spellings:

```python
elif (
    conf.redis_url.startswith(('redis-sentinel', 'sentinel://', 'redis+sentinel://'))
    and 'sentinels' in redis_options
):
```

## Scope — please read

This is deliberately **only** a scheme match, not full celery-native sentinel
support. The `and 'sentinels' in redis_options` condition is unchanged, so this
helps only if `redbeat_redis_options` (or `broker_transport_options`) already
supplies an explicit `sentinels` list. A purely celery-native config —
`master_name` in `broker_transport_options` with hosts derived from a
`;`-joined `sentinel://` URL — still falls through and still raises.

The `CHANGES.txt` entry and the new `docs/config.rst` paragraph both say so
explicitly, so nobody reads this as more than it is. If you'd rather this go
the whole way and derive `sentinels`/`master_name` from the URL, that's a
larger change and worth its own issue.

## Test plan

- Added regression coverage in `tests/test_scheduler.py` for both new aliases.
- `make test` passes (91 tests).

Closes #199

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAnuwguSXH8EJ78MYTEWjH)_