### PR TITLE
bugfix: drop the cached producer after a connection-shaped dispatch failure

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,10 @@
 2.4.3 (unreleased)
 ---------------------
+  - bugfix, drop the cached broker producer/connection after a dispatch
+    fails with a connection-shaped error, so beat reconnects on the next
+    tick instead of retrying the same dead connection for the life of the
+    process; a non-connection dispatch failure (e.g. a bad task payload)
+    leaves a healthy connection alone, refs #201
   - doc, document that RedBeat supports both Redis and Valkey servers, with
     intent to maintain both absent major upstream behaviour changes, and
     that redis-py is the only supported client library, #301

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -582,13 +582,8 @@ class RedBeatScheduler(Scheduler):
                 result = self.apply_async(entry, **kwargs)
             except Exception as exc:
                 logger.exception('Scheduler: Message Error: %s', exc)
-                # self.producer/self.connection (celery.beat.Scheduler
-                # cached_properties) pin dispatch to one connection for the
-                # life of the process. If the failure looks connection-shaped
-                # -- as opposed to e.g. a bad/unserializable task payload
-                # against an otherwise healthy broker -- drop the cached
-                # values so the next tick reconnects instead of retrying the
-                # same dead connection forever.
+                # celery caches producer/connection for the life of the process,
+                # so a dead connection never heals unless we drop it
                 if self._is_connection_error(exc):
                     self._discard_connection()
             else:
@@ -609,12 +604,8 @@ class RedBeatScheduler(Scheduler):
                 try:
                     due_kwargs = self._maybe_due_kwargs
                 except Exception as exc:
-                    # _maybe_due_kwargs resolves self.producer, which -- after
-                    # a prior dispatch failure discarded it -- reconnects via
-                    # celery's _ensure_connected(). That can itself raise
-                    # (kombu.exceptions.OperationalError) if the broker is
-                    # still unreachable; it must not escape tick() and stall
-                    # the redbeat lock renewal for the rest of the entries.
+                    # resolving .producer reconnects, which can raise if the
+                    # broker is still down; must not stall lock renewal
                     logger.exception('Scheduler: Reconnect Error: %s', exc)
                     if self._is_connection_error(exc):
                         self._discard_connection()
@@ -632,14 +623,8 @@ class RedBeatScheduler(Scheduler):
     def _is_connection_error(self, exc):
         """Is exc (or the error it wraps) a broker connection failure?
 
-        celery.beat.Scheduler.apply_async wraps *every* exception raised by
-        send_task/apply_async -- serialization errors, unknown tasks, a bad
-        broker connection, anything -- in SchedulingError, with the original
-        exception available via implicit chaining as ``__context__`` (or, on
-        celery versions that raise it with `from`, ``__cause__``). Treating
-        every SchedulingError as connection-shaped would tear down a healthy
-        producer/connection just because e.g. one entry's payload isn't
-        JSON-serializable, so unwrap it and check the real cause.
+        apply_async wraps every exception in SchedulingError, so unwrap it --
+        a bad task payload must not tear down a healthy connection.
         """
         candidates = (exc, exc.__cause__, exc.__context__)
         errors = (OperationalError,)
@@ -651,11 +636,8 @@ class RedBeatScheduler(Scheduler):
     def _discard_connection(self):
         """Drop the cached producer/connection so the next tick reconnects.
 
-        celery.beat.Scheduler.producer/.connection are cached_property, so
-        once resolved they pin dispatch to one connection for the life of
-        the process. kombu.Connection defines no __del__, so just popping it
-        out of __dict__ leaks the socket -- release it first (best-effort;
-        it may already be dead).
+        kombu.Connection has no __del__, so release before popping or the
+        socket leaks.
         """
         connection = self.__dict__.pop('connection', None)
         if connection is not None:

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -16,7 +16,7 @@ from celery.beat import DEFAULT_MAX_INTERVAL, ScheduleEntry, Scheduler
 from celery.signals import beat_init
 from celery.utils.log import get_logger
 from celery.utils.time import humanize_seconds
-from kombu.utils.objects import cached_property
+from kombu.exceptions import OperationalError
 from kombu.utils.url import maybe_sanitize_url
 from redis import Redis
 from redis.sentinel import MasterNotFoundError, Sentinel
@@ -582,6 +582,15 @@ class RedBeatScheduler(Scheduler):
                 result = self.apply_async(entry, **kwargs)
             except Exception as exc:
                 logger.exception('Scheduler: Message Error: %s', exc)
+                # self.producer/self.connection (celery.beat.Scheduler
+                # cached_properties) pin dispatch to one connection for the
+                # life of the process. If the failure looks connection-shaped
+                # -- as opposed to e.g. a bad/unserializable task payload
+                # against an otherwise healthy broker -- drop the cached
+                # values so the next tick reconnects instead of retrying the
+                # same dead connection forever.
+                if self._is_connection_error(exc):
+                    self._discard_connection()
             else:
                 if result and hasattr(result, 'id'):
                     logger.debug('Scheduler: %s sent. id->%s', entry.task, result.id)
@@ -597,13 +606,64 @@ class RedBeatScheduler(Scheduler):
         remaining_times = []
         try:
             for entry in self.schedule.values():
-                next_time_to_run = self.maybe_due(entry, **self._maybe_due_kwargs)
+                try:
+                    due_kwargs = self._maybe_due_kwargs
+                except Exception as exc:
+                    # _maybe_due_kwargs resolves self.producer, which -- after
+                    # a prior dispatch failure discarded it -- reconnects via
+                    # celery's _ensure_connected(). That can itself raise
+                    # (kombu.exceptions.OperationalError) if the broker is
+                    # still unreachable; it must not escape tick() and stall
+                    # the redbeat lock renewal for the rest of the entries.
+                    logger.exception('Scheduler: Reconnect Error: %s', exc)
+                    if self._is_connection_error(exc):
+                        self._discard_connection()
+                        continue
+                    raise
+
+                next_time_to_run = self.maybe_due(entry, **due_kwargs)
                 if next_time_to_run:
                     remaining_times.append(next_time_to_run)
         except RuntimeError:
             logger.debug('beat: RuntimeError', exc_info=True)
 
         return min(remaining_times + [self.max_interval])
+
+    def _is_connection_error(self, exc):
+        """Is exc (or the error it wraps) a broker connection failure?
+
+        celery.beat.Scheduler.apply_async wraps *every* exception raised by
+        send_task/apply_async -- serialization errors, unknown tasks, a bad
+        broker connection, anything -- in SchedulingError, with the original
+        exception available via implicit chaining as ``__context__`` (or, on
+        celery versions that raise it with `from`, ``__cause__``). Treating
+        every SchedulingError as connection-shaped would tear down a healthy
+        producer/connection just because e.g. one entry's payload isn't
+        JSON-serializable, so unwrap it and check the real cause.
+        """
+        candidates = (exc, exc.__cause__, exc.__context__)
+        errors = (OperationalError,)
+        connection = self.__dict__.get('connection')
+        if connection is not None:
+            errors += tuple(connection.connection_errors) + tuple(connection.channel_errors)
+        return any(isinstance(candidate, errors) for candidate in candidates if candidate)
+
+    def _discard_connection(self):
+        """Drop the cached producer/connection so the next tick reconnects.
+
+        celery.beat.Scheduler.producer/.connection are cached_property, so
+        once resolved they pin dispatch to one connection for the life of
+        the process. kombu.Connection defines no __del__, so just popping it
+        out of __dict__ leaks the socket -- release it first (best-effort;
+        it may already be dead).
+        """
+        connection = self.__dict__.pop('connection', None)
+        if connection is not None:
+            try:
+                connection.release()
+            except Exception:
+                logger.debug('beat: error releasing stale connection', exc_info=True)
+        self.__dict__.pop('producer', None)
 
     def close(self):
         if self.lock:
@@ -624,7 +684,7 @@ class RedBeatScheduler(Scheduler):
             )
         return '\n'.join(info)
 
-    @cached_property
+    @property
     def _maybe_due_kwargs(self):
         """handle rename of publisher to producer"""
         return {'producer': self.producer}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -221,13 +221,8 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
             self.s.tick()
 
     def test_dispatch_failure_from_a_dead_connection_is_recovered_on_next_dispatch(self):
-        # celery.beat.Scheduler.producer/.connection are cached_property, so
-        # once resolved they pin dispatch to a single connection for the life
-        # of the process. If a dispatch fails because that connection died (an
-        # idle socket reaped by the broker, a proxy failover, ...) the failure
-        # is logged loudly (logger.exception) -- but every following dispatch
-        # keeps failing against the same dead connection unless the cached
-        # producer/connection are dropped so the next tick reconnects.
+        # a dispatch against a dead connection must drop the cached
+        # producer/connection, or every later dispatch fails the same way
         entry = self.create_entry(
             name='now', s=due_now, last_run_at=datetime.utcnow() - timedelta(seconds=1)
         ).save()
@@ -242,18 +237,13 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
         with patch.object(self.s, 'send_task', side_effect=ConnectionError('boom')):
             self.s.maybe_due(entry, producer=dead_producer)
 
-        # the dead connection is released (not just discarded, kombu.Connection
-        # has no __del__) and both cached values are gone
+        # released, not just discarded -- kombu.Connection has no __del__
         dead_connection.release.assert_called_once()
         self.assertNotIn('connection', self.s.__dict__)
         self.assertNotIn('producer', self.s.__dict__)
 
-        # and the *next* dispatch actually gets a different producer object --
-        # this is the behaviour, not just the absence of __dict__ keys. It
-        # also exercises _maybe_due_kwargs being a plain property rather than
-        # a cached_property: a cached_property here would keep handing out
-        # the stale producer even after the pops above (see also PR #329,
-        # which independently makes this same _maybe_due_kwargs change).
+        # the next dispatch gets a different producer -- the behaviour, not
+        # just the absence of __dict__ keys
         fresh_producer = Mock(name='fresh-producer')
         with patch.object(
             type(self.s), 'producer', new_callable=PropertyMock, return_value=fresh_producer
@@ -266,11 +256,8 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
         self.assertIsNot(used_producer, dead_producer)
 
     def test_maybe_due_kwargs_reflects_a_fresh_producer_each_call(self):
-        # _maybe_due_kwargs must not be a cached_property (see PR #329, which
-        # independently makes this same change): `producer` is itself a
-        # cached_property, and pinning `_maybe_due_kwargs` on top of it would
-        # keep handing out a stale producer dict forever, even after
-        # `producer` itself has been discarded and re-resolved.
+        # a cached_property here would keep handing out a stale producer even
+        # after the underlying one is discarded and re-resolved
         producers = [Mock(name='first'), Mock(name='second')]
         with patch.object(type(self.s), 'producer', new_callable=PropertyMock) as producer:
             producer.side_effect = producers
@@ -281,11 +268,8 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
         self.assertIs(second, producers[1])
 
     def test_dispatch_failure_from_a_bad_payload_keeps_a_healthy_connection(self):
-        # A pure serialization/scheduling error against an otherwise healthy
-        # broker (e.g. an entry whose args aren't JSON-serializable) must not
-        # tear down the cached producer/connection -- unlike a real connection
-        # failure, discarding here buys nothing and would open a fresh broker
-        # connection on every tick for as long as the bad entry stays due.
+        # a bad payload against a healthy broker must not tear down the
+        # connection -- that would reconnect every tick for nothing
         self.create_entry(
             name='now', s=due_now, last_run_at=datetime.utcnow() - timedelta(seconds=1)
         ).save()
@@ -309,12 +293,8 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
         connection.release.assert_not_called()
 
     def test_reconnect_failure_during_tick_does_not_escape_or_stall(self):
-        # After a prior dispatch failure has discarded the cache, the next
-        # tick's attempt to re-resolve self.producer goes through celery's
-        # _ensure_connected(), which can itself raise OperationalError if the
-        # broker is still unreachable. That must not escape tick() -- it would
-        # otherwise crash the beat loop (or, uncaught by the caller, leave the
-        # redbeat lock unextended) instead of just trying again next tick.
+        # re-resolving .producer reconnects and can raise if the broker is
+        # still down; that must not escape tick() and stall lock renewal
         self.create_entry(
             name='now', s=due_now, last_run_at=datetime.utcnow() - timedelta(seconds=1)
         ).save()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,12 +3,13 @@ import unittest
 from copy import deepcopy
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytz
 from celery.beat import DEFAULT_MAX_INTERVAL
 from celery.schedules import schedstate, schedule
 from celery.utils.time import maybe_timedelta
+from kombu.exceptions import OperationalError
 from redis import CredentialProvider
 from redis.exceptions import ConnectionError
 
@@ -218,6 +219,115 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
         self.s.lock = None
         with self.assertRaises(AttributeError):
             self.s.tick()
+
+    def test_dispatch_failure_from_a_dead_connection_is_recovered_on_next_dispatch(self):
+        # celery.beat.Scheduler.producer/.connection are cached_property, so
+        # once resolved they pin dispatch to a single connection for the life
+        # of the process. If a dispatch fails because that connection died (an
+        # idle socket reaped by the broker, a proxy failover, ...) the failure
+        # is logged loudly (logger.exception) -- but every following dispatch
+        # keeps failing against the same dead connection unless the cached
+        # producer/connection are dropped so the next tick reconnects.
+        entry = self.create_entry(
+            name='now', s=due_now, last_run_at=datetime.utcnow() - timedelta(seconds=1)
+        ).save()
+
+        dead_connection = Mock(name='dead-connection')
+        dead_connection.connection_errors = (ConnectionError,)
+        dead_connection.channel_errors = ()
+        dead_producer = Mock(name='dead-producer')
+        self.s.__dict__['connection'] = dead_connection
+        self.s.__dict__['producer'] = dead_producer
+
+        with patch.object(self.s, 'send_task', side_effect=ConnectionError('boom')):
+            self.s.maybe_due(entry, producer=dead_producer)
+
+        # the dead connection is released (not just discarded, kombu.Connection
+        # has no __del__) and both cached values are gone
+        dead_connection.release.assert_called_once()
+        self.assertNotIn('connection', self.s.__dict__)
+        self.assertNotIn('producer', self.s.__dict__)
+
+        # and the *next* dispatch actually gets a different producer object --
+        # this is the behaviour, not just the absence of __dict__ keys. It
+        # also exercises _maybe_due_kwargs being a plain property rather than
+        # a cached_property: a cached_property here would keep handing out
+        # the stale producer even after the pops above (see also PR #329,
+        # which independently makes this same _maybe_due_kwargs change).
+        fresh_producer = Mock(name='fresh-producer')
+        with patch.object(
+            type(self.s), 'producer', new_callable=PropertyMock, return_value=fresh_producer
+        ):
+            with patch.object(self.s, 'send_task') as send_task:
+                self.s.maybe_due(entry, **self.s._maybe_due_kwargs)
+
+        used_producer = send_task.call_args.kwargs.get('producer')
+        self.assertIs(used_producer, fresh_producer)
+        self.assertIsNot(used_producer, dead_producer)
+
+    def test_maybe_due_kwargs_reflects_a_fresh_producer_each_call(self):
+        # _maybe_due_kwargs must not be a cached_property (see PR #329, which
+        # independently makes this same change): `producer` is itself a
+        # cached_property, and pinning `_maybe_due_kwargs` on top of it would
+        # keep handing out a stale producer dict forever, even after
+        # `producer` itself has been discarded and re-resolved.
+        producers = [Mock(name='first'), Mock(name='second')]
+        with patch.object(type(self.s), 'producer', new_callable=PropertyMock) as producer:
+            producer.side_effect = producers
+            first = self.s._maybe_due_kwargs['producer']
+            second = self.s._maybe_due_kwargs['producer']
+
+        self.assertIs(first, producers[0])
+        self.assertIs(second, producers[1])
+
+    def test_dispatch_failure_from_a_bad_payload_keeps_a_healthy_connection(self):
+        # A pure serialization/scheduling error against an otherwise healthy
+        # broker (e.g. an entry whose args aren't JSON-serializable) must not
+        # tear down the cached producer/connection -- unlike a real connection
+        # failure, discarding here buys nothing and would open a fresh broker
+        # connection on every tick for as long as the bad entry stays due.
+        self.create_entry(
+            name='now', s=due_now, last_run_at=datetime.utcnow() - timedelta(seconds=1)
+        ).save()
+
+        connection = Mock(name='healthy-connection')
+        connection.connection_errors = (ConnectionError,)
+        connection.channel_errors = ()
+        producer = Mock(name='healthy-producer')
+        self.s.__dict__['connection'] = connection
+        self.s.__dict__['producer'] = producer
+
+        with patch.object(
+            self.s,
+            'send_task',
+            side_effect=TypeError('Object of type set is not JSON serializable'),
+        ):
+            self.s.tick()
+
+        self.assertIs(self.s.__dict__.get('connection'), connection)
+        self.assertIs(self.s.__dict__.get('producer'), producer)
+        connection.release.assert_not_called()
+
+    def test_reconnect_failure_during_tick_does_not_escape_or_stall(self):
+        # After a prior dispatch failure has discarded the cache, the next
+        # tick's attempt to re-resolve self.producer goes through celery's
+        # _ensure_connected(), which can itself raise OperationalError if the
+        # broker is still unreachable. That must not escape tick() -- it would
+        # otherwise crash the beat loop (or, uncaught by the caller, leave the
+        # redbeat lock unextended) instead of just trying again next tick.
+        self.create_entry(
+            name='now', s=due_now, last_run_at=datetime.utcnow() - timedelta(seconds=1)
+        ).save()
+
+        with patch.object(
+            type(self.s),
+            'producer',
+            new_callable=PropertyMock,
+            side_effect=OperationalError('still down'),
+        ):
+            sleep = self.s.tick()  # must not raise
+
+        self.assertEqual(sleep, self.s.max_interval)
 
 
 class TestRedBeatSchedulerUpdateFromDict(RedBeatSchedulerTestBase):


### PR DESCRIPTION
## What & why

`celery.beat.Scheduler.producer` and `.connection` are `cached_property`, and
RedBeat added a second layer by making `_maybe_due_kwargs` a `cached_property`
on top. A beat process therefore resolves one broker connection on its first
tick and reuses it forever.

If that connection dies (idle reap, proxy failover, TCP reset), every later
publish fails — invisibly. `apply_async` persists `last_run_at` /
`total_run_count` / the ZSET score *before* publishing, and `maybe_due` catches
the publish exception and only logs it. RedBeat's own redis-py client reconnects
independently, so every Redis-side signal keeps advancing and looks healthy.
Tasks just stop reaching workers.

## Fix

Three parts:

1. `_maybe_due_kwargs` becomes a plain `@property`.
2. On a dispatch failure, if the error is connection-shaped, discard the cached
   `producer`/`connection` so the next tick reconnects. `_discard_connection()`
   calls `connection.release()` before popping it — `kombu.Connection` has no
   `__del__`, so popping alone leaks the socket.
3. `_maybe_due_kwargs` resolution inside `tick()` is wrapped, because after a
   discard it reconnects via celery's `_ensure_connected()` and can itself raise
   `OperationalError` if the broker is still down. That must not escape `tick()`
   and stall redbeat lock renewal for the remaining entries.

**(2) is the part that does the work.** (1) on its own is a no-op: celery's
`producer` is itself a `cached_property` that nothing ever invalidates, so
re-reading it just returns the same object out of the instance `__dict__`. It's
kept here only so the discard in (2) is actually observable on the next tick.

The connection-shaped check matters: `celery.beat.Scheduler.apply_async` wraps
*every* exception in `SchedulingError`, so treating them all as connection
failures would tear down a healthy producer just because one entry's payload
isn't serializable. `_is_connection_error` unwraps `__cause__`/`__context__` and
checks against `OperationalError` plus the live connection's own
`connection_errors`/`channel_errors`.

## Test plan

- Added coverage in `tests/test_scheduler.py` for: fresh producer per tick,
  discard-on-connection-error, *no* discard on a non-connection error, and the
  reconnect-raises path in `tick()`.
- `make test` passes (90 tests).

## Relationship to #329

#329 diagnoses the same symptom and its writeup of the failure mechanics is
accurate, but its fix is only change (1) — which per the analysis in
https://github.com/sibson/redbeat/pull/329#issuecomment-5154002120 does not
change runtime behaviour. This branch implements the invalidate-on-failure
approach identified as point 4 of that comment.

## Open question before this leaves draft

That same review asked for empirical evidence that the wedge actually occurs —
a run of `Scheduler: Message Error` lines from a real deployment, with an
exception class falling outside the transport's `recoverable_connection_errors`.
That evidence hasn't materialised. For errors the transport classifies as
recoverable, kombu's `publish(retry=True)` already heals the connection in place
on the pinned producer, so this fix only bites for the unrecoverable-error case.

Marked `refs #201` rather than `fixes #201` in `CHANGES.txt` pending that.

Refs #201