### PR TITLE
build: run flake8 and pip under the same interpreter as the tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,11 +6,16 @@ test: unittests
 
 setup:
 	python -m pip install --upgrade pip
-	pip install -r requirements-dev.txt
-	pip install -e .
+	python -m pip install -r requirements-dev.txt
+	python -m pip install -e .
 
+# invoke via `python -m` rather than the bare `flake8`/`pip` console scripts, so
+# the linter runs under the same interpreter as `make setup` and `make
+# unittests`. A bare `flake8` resolves through PATH and can land in an unrelated
+# environment (a pipx/uv tool venv, say) that lacks flake8-black/flake8-isort --
+# in which case flake8 still exits 0, silently skipping every check CI enforces.
 lint:
-	flake8 redbeat tests
+	python -m flake8 redbeat tests
 
 build:
 	python -m pip install --upgrade build && python -m build


### PR DESCRIPTION
## What & why

`make lint` ran the bare `flake8` console script, which resolves through `PATH`
and need not be the interpreter `make unittests` and `make setup` use. In this
repo's web-session container it resolved to a uv tool venv
(`/root/.local/share/uv/tools/flake8/`) that had no plugins, while
`flake8-black` and `flake8-isort` were installed into a different Python
entirely.

The failure is silent in the worst way: flake8 runs, finds no plugins, checks
only pycodestyle/pyflakes, and **exits 0**. Both black and isort — the checks CI
actually enforces — are skipped, and `setup.cfg`'s `black-config =
./pyproject.toml` is ignored because no plugin registers that option. `make
lint` passes locally and the lint job fails on the PR.

## Fix

Invoke through `python -m` so the linter binds to the same interpreter as
everything else:

```make
lint:
	python -m flake8 redbeat tests
```

`setup` had the same split — line 1 used `python -m pip`, the next two used a
bare `pip` — so those are now `python -m pip` too. That inconsistency is
plausibly how the two-interpreter state arose in the first place.

## Test plan

- `make lint` now reports `flake8 7.3.0 (flake8-black: 0.4.0, flake8-isort:
  7.0.0, …)` and exits 0 with the plugins genuinely loaded — verified against a
  scratch file that `BLK100`, `I001` and `I003` all fire, and that
  `skip-string-normalization` from `pyproject.toml` is honored rather than black
  rewriting single quotes.
- Zero violations on current `main`; nothing reformatted.
- `make test` passes (89 tests).

No `CHANGES.txt` entry — this is build tooling, not a user-visible change.

## Note on CI

CI is unaffected: `.github/workflows/ci.yml` installs `flake8 flake8-black
flake8-isort` into the job's only Python and calls `flake8` directly, so it was
always running the real checks. This only fixes local/web-session runs, where
the mismatch made `make lint` a no-op.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAnuwguSXH8EJ78MYTEWjH)_