### PR TITLE
bugfix: wrap cluster key prefix in a Redis hash tag

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -47,7 +47,12 @@ Additional SSL options used when using the ``rediss`` scheme in
 ``redbeat_key_prefix``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-A prefix for all keys created by RedBeat, defaults to ``'redbeat'``.
+A prefix for all keys created by RedBeat, defaults to ``'redbeat:'``.
+
+On Redis Cluster, RedBeat wraps an untagged prefix in ``{...}`` so the
+entry hash and the schedule ZSET land in the same hash slot. Supply your
+own tag (for example ``'{redbeat:}'``) if you want to control the slot.
+Standalone Redis is unchanged.
 
 ``redbeat_lock_key``
 ~~~~~~~~~~~~~~~~~~~~
@@ -133,4 +138,12 @@ Some notes about the configuration:
 * hostname and port are ignored within the actual URL. Redis Cluster
   uses the ``startup_nodes`` option, and the remaining options are sent
   as keyword arguments to ``RedisCluster()``.
+
+* Redis Cluster requires keys used together in a pipeline to share a
+  hash slot. Saving an entry writes both ``<prefix><name>`` and
+  ``<prefix>:schedule`` in one ``MULTI``, so an untagged prefix raises
+  ``CROSSSLOT``. When cluster mode is detected (``redis-cluster://`` or
+  ``redbeat_redis_options['cluster'] = True``), RedBeat wraps the prefix
+  in ``{...}`` unless it already contains a hash tag. Standalone and
+  Sentinel deployments are not rewritten.
 

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -237,12 +237,31 @@ Couldn't add entry %r to redis schedule: %r. Contents: %r
 """
 
 
+def has_redis_hash_tag(key):
+    """True if *key* contains a non-empty Redis hash tag ``{...}``."""
+    start = key.find('{')
+    if start < 0:
+        return False
+    end = key.find('}', start + 1)
+    return end > start + 1
+
+
+def ensure_redis_hash_tag(prefix):
+    """Wrap *prefix* in ``{...}`` so related keys share a Redis Cluster slot.
+
+    Pipelines in RedBeat touch both the entry hash (``prefix + name``) and the
+    schedule ZSET (``prefix + ':schedule'``). Without a shared hash tag those
+    keys land in different slots and Redis Cluster raises CROSSSLOT (#296).
+    """
+    if has_redis_hash_tag(prefix):
+        return prefix
+    return '{' + prefix + '}'
+
+
 class RedBeatConfig:
     def __init__(self, app=None):
         self.app = app_or_default(app)
         self.key_prefix = self.either_or('redbeat_key_prefix', 'redbeat:')
-        self.schedule_key = self.key_prefix + ':schedule'
-        self.statics_key = self.key_prefix + ':statics'
         self.redis_url = self.either_or('redbeat_redis_url', app.conf['BROKER_URL'])
         if not self.is_key_in_conf('redbeat_redis_url'):
             # also log it: DeprecationWarning is silenced by default and beat
@@ -264,6 +283,10 @@ class RedBeatConfig:
             )
             warnings.warn(message, DeprecationWarning, stacklevel=2)
             logger.warning(message)
+        if self._uses_redis_cluster():
+            self.key_prefix = ensure_redis_hash_tag(self.key_prefix)
+        self.schedule_key = self.key_prefix + ':schedule'
+        self.statics_key = self.key_prefix + ':statics'
         self.lock_key = self.either_or('redbeat_lock_key', self.key_prefix + ':lock')
         if self.lock_key and not self.lock_key.startswith(self.key_prefix):
             self.lock_key = self.key_prefix + self.lock_key
@@ -276,6 +299,13 @@ class RedBeatConfig:
     @schedule.setter
     def schedule(self, value):
         self.app.conf.beat_schedule = value
+
+    def _uses_redis_cluster(self):
+        options = self.redbeat_redis_options or {}
+        if options.get('cluster'):
+            return True
+        url = self.redis_url or ''
+        return url.startswith('redis-cluster')
 
     def either_or(self, name, default=None):
         if name == name.upper():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from celery.contrib.testing.app import TestApp
 
-from redbeat.schedulers import RedBeatConfig
+from redbeat.schedulers import RedBeatConfig, ensure_redis_hash_tag, has_redis_hash_tag
 from tests.basecase import AppCase
 
 
@@ -31,6 +31,10 @@ class test_RedBeatConfig(AppCase):
         self.app.conf.redbeat_key_prefix = 'test-prefix:'
         self.conf = RedBeatConfig(self.app)
         self.assertEqual(self.conf.key_prefix, 'test-prefix:')
+
+    def test_standalone_prefix_is_not_hash_tagged(self):
+        self.assertFalse(has_redis_hash_tag(self.conf.key_prefix))
+        self.assertEqual(self.conf.schedule_key, 'redbeat::schedule')
 
     def test_lock_key_might_be_set_to_none(self):
         self.app.conf.redbeat_lock_key = None
@@ -87,3 +91,54 @@ class test_BrokerFallbackDeprecation(AppCase):
     def test_no_options_warning_when_broker_options_empty(self):
         messages = self.deprecation_messages({'redbeat_redis_url': 'redis://'})
         self.assertFalse(any('redbeat_redis_options' in m for m in messages))
+
+
+class test_RedisClusterHashTags(AppCase):
+    def setup(self):
+        pass
+
+    def test_ensure_wraps_untagged_prefix(self):
+        self.assertEqual(ensure_redis_hash_tag('redbeat:'), '{redbeat:}')
+        self.assertEqual(ensure_redis_hash_tag('redbeat_staging-'), '{redbeat_staging-}')
+
+    def test_ensure_leaves_existing_tag_alone(self):
+        self.assertEqual(ensure_redis_hash_tag('{redbeat:}'), '{redbeat:}')
+        self.assertEqual(ensure_redis_hash_tag('env:{redbeat:}'), 'env:{redbeat:}')
+
+    def test_empty_braces_are_not_a_tag(self):
+        self.assertFalse(has_redis_hash_tag('{}prefix'))
+        self.assertEqual(ensure_redis_hash_tag('{}prefix'), '{{}prefix}')
+
+    def test_cluster_url_wraps_default_prefix(self):
+        self.app.conf.redbeat_redis_url = 'redis-cluster://redis-cluster:30001/0'
+        self.app.conf.redbeat_redis_options = {
+            'startup_nodes': [{"host": "127.0.0.1", "port": 30001}],
+        }
+        conf = RedBeatConfig(self.app)
+        self.assertEqual(conf.key_prefix, '{redbeat:}')
+        self.assertEqual(conf.schedule_key, '{redbeat:}:schedule')
+        self.assertEqual(conf.statics_key, '{redbeat:}:statics')
+        self.assertEqual(conf.lock_key, '{redbeat:}:lock')
+
+    def test_cluster_flag_wraps_custom_prefix(self):
+        self.app.conf.redbeat_key_prefix = 'redbeat_staging-'
+        self.app.conf.redbeat_redis_url = 'redis://localhost:6379/0'
+        self.app.conf.redbeat_redis_options = {'cluster': True}
+        conf = RedBeatConfig(self.app)
+        self.assertEqual(conf.key_prefix, '{redbeat_staging-}')
+        # entry hash and schedule ZSET must share the same tag (CROSSSLOT otherwise)
+        entry_key = conf.key_prefix + 'removing_users'
+        self.assertTrue(has_redis_hash_tag(entry_key))
+        self.assertTrue(has_redis_hash_tag(conf.schedule_key))
+        self.assertIn('{redbeat_staging-}', entry_key)
+        self.assertIn('{redbeat_staging-}', conf.schedule_key)
+
+    def test_cluster_respects_user_supplied_hash_tag(self):
+        self.app.conf.redbeat_key_prefix = '{myapp:redbeat:}'
+        self.app.conf.redbeat_redis_url = 'redis-cluster://redis-cluster:30001/0'
+        self.app.conf.redbeat_redis_options = {
+            'startup_nodes': [{"host": "127.0.0.1", "port": 30001}],
+        }
+        conf = RedBeatConfig(self.app)
+        self.assertEqual(conf.key_prefix, '{myapp:redbeat:}')
+        self.assertEqual(conf.schedule_key, '{myapp:redbeat:}:schedule')


### PR DESCRIPTION
## Summary

Saving a schedule entry writes the entry hash (`prefix + name`) and the schedule ZSET (`prefix + ':schedule'`) in one Redis `MULTI`. On Redis Cluster those keys hash to different slots unless they share a hash tag, which is the CROSSSLOT failure in #296.

When cluster mode is detected (`redis-cluster://` or `redbeat_redis_options['cluster'] = True`) and the prefix has no `{…}` tag, wrap it so both keys land in the same slot. A user-supplied tag is left alone. Standalone Redis and Sentinel are not rewritten.

Also notes the requirement in the cluster docs, and corrects the documented default prefix to `redbeat:` (matching the code).

## Test plan

- [x] `python -m unittest discover tests` (97 passed, 2 skipped)
- [x] `flake8 redbeat tests`
- [ ] Confirm a cluster install with an untagged prefix no longer raises CROSSSLOT on `entry.save()`
- [ ] Confirm a standalone Redis install still uses `redbeat:` keys

fixes #296