### PR TITLE
feature: warn when Redis is configured to evict RedBeat's keys

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,8 @@
 2.4.3 (unreleased)
 ---------------------
-  - feature, check at beat startup for Redis configuration that lets RedBeat's
-    keys expire or be evicted, an expiry on the schedule or statics keys and an
-    evicting maxmemory-policy, and report it in the log and the beat banner;
-    controlled by redbeat_key_expiry_check, #291
+  - feature, check at startup for a Redis maxmemory-policy that can evict
+    RedBeat's keys, and report it in the log and the beat banner; controlled
+    by redbeat_key_expiry_check, #291
   - bugfix, raise the log level from warning to error when a scheduled
     entry's hash is missing (e.g. evicted by Redis) and the entry is
     dropped from the schedule, so operators notice instead of the loss

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 2.4.3 (unreleased)
 ---------------------
+  - feature, check at beat startup for Redis configuration that lets RedBeat's
+    keys expire or be evicted, an expiry on the schedule or statics keys and an
+    evicting maxmemory-policy, and report it in the log and the beat banner;
+    controlled by redbeat_key_expiry_check, #291
   - bugfix, raise the log level from warning to error when a scheduled
     entry's hash is missing (e.g. evicted by Redis) and the entry is
     dropped from the schedule, so operators notice instead of the loss

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -55,6 +55,23 @@ A prefix for all keys created by RedBeat, defaults to ``'redbeat'``.
 Key used to ensure only a single beat instance runs at a time,
 defaults to ``'<redbeat_key_prefix>:lock'``.
 
+``redbeat_key_expiry_check``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+What RedBeat does at startup when it finds Redis configured to let its keys
+expire or be evicted, see requirements_ below. One of:
+
+``'ignore'``
+    Skip the checks entirely, and the two commands they cost.
+``'warn'``
+    Log any finding at ``WARNING``.
+``'error'``
+    Log any finding at ``ERROR``. The default.
+``'raise'``
+    Log any finding at ``ERROR``, then refuse to start.
+
+.. versionadded:: 2.4.3
+
 ``redbeat_lock_timeout``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -134,3 +151,53 @@ Some notes about the configuration:
   uses the ``startup_nodes`` option, and the remaining options are sent
   as keyword arguments to ``RedisCluster()``.
 
+.. _requirements:
+
+Redis requirements
+------------------
+
+RedBeat's keys are the schedule, not a cache of it. Nothing recreates them:
+an entry whose hash disappears stops running, and RedBeat notices only when
+the entry next comes due, at which point it logs
+
+.. code-block:: text
+
+    beat: Failed to load redbeat:some-task, removing; its hash is gone, which
+    usually means Redis evicted or expired it
+
+Entries defined in ``beat_schedule`` come back at the next beat restart;
+entries created through the API are gone for good. So RedBeat's keys must
+never expire, and the Redis holding them must never evict them.
+
+Two ways deployments break that:
+
+* an eviction policy. With ``maxmemory`` set and a ``maxmemory-policy`` in
+  the ``allkeys-*`` family, Redis may drop any key, including the schedule,
+  once memory runs short. The ``volatile-*`` policies only drop keys carrying
+  an expiry.
+* an expiry on the keys themselves, usually housekeeping on a shared Redis,
+  or a ``redbeat:*`` sweep modelled on the lock key.
+
+Use the ``noeviction`` policy, or give RedBeat a Redis instance or database
+of its own. ``redbeat::lock`` is the one deliberate exception: it is supposed
+to expire, that is what releases the lock when a beat process dies.
+
+At startup RedBeat checks what it can afford to check: whether
+``redbeat::schedule`` or ``redbeat::statics`` carry an expiry, and whether
+the server reports an evicting ``maxmemory-policy``. Findings are logged and
+repeated in the beat banner, under the control of ``redbeat_key_expiry_check``
+above. It does not walk the individual entry hashes, which would cost a round
+trip per entry on every beat startup. To check those by hand::
+
+    redis-cli --scan --pattern 'redbeat:*' | while read key; do
+        ttl=$(redis-cli ttl "$key")
+        test "$ttl" -ge 0 && echo "$key expires in ${ttl}s"
+    done
+
+The startup check needs no more than ``CONFIG GET``, and quietly skips the
+policy half when the server refuses it, as several managed Redis offerings
+do. A server RedBeat cannot ask is never reported as unsafe, so on those
+deployments check ``maxmemory-policy`` yourself through the provider console.
+
+Programs that create entries through the API without running beat never reach
+the startup check, since it is beat that runs it.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -68,7 +68,8 @@ keys, see requirements_ below. One of:
 ``'error'``
     Log any finding at ``ERROR``. The default.
 ``'raise'``
-    Log any finding at ``ERROR``, then refuse to start.
+    Log any finding at ``ERROR``, then refuse to start. Also refuses to start
+    when the policy cannot be read at all, see requirements_ below.
 
 .. versionadded:: 2.4.3
 
@@ -188,10 +189,12 @@ applies expiries to ``redbeat:*``, look for them yourself::
         test "$ttl" -ge 0 && echo "$key expires in ${ttl}s"
     done
 
-Several managed Redis offerings disable or rename ``CONFIG``. RedBeat logs
-that it could not read the policy and starts anyway, even in ``'raise'``
-mode: a server it cannot ask is not a server it calls unsafe. Check
-``maxmemory-policy`` through the provider console instead.
+Several managed Redis offerings disable or rename ``CONFIG``. RedBeat logs a
+warning that it could not read the policy and starts anyway, since a server
+it cannot ask is not a server it calls unsafe. Under ``'raise'`` it refuses
+to start instead: asking RedBeat to be strict about eviction is asking it to
+be strict about not knowing. Check ``maxmemory-policy`` through the provider
+console, and use one of the other modes if it cannot be read from RedBeat.
 
 Programs that create entries through the API without running beat never reach
 the check, since it runs when the scheduler is built.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -58,11 +58,11 @@ defaults to ``'<redbeat_key_prefix>:lock'``.
 ``redbeat_key_expiry_check``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-What RedBeat does at startup when it finds Redis configured to let its keys
-expire or be evicted, see requirements_ below. One of:
+What RedBeat does at startup when it finds Redis configured to evict its
+keys, see requirements_ below. One of:
 
 ``'ignore'``
-    Skip the checks entirely, and the two commands they cost.
+    Skip the check, and the one command it costs.
 ``'warn'``
     Log any finding at ``WARNING``.
 ``'error'``
@@ -169,35 +169,29 @@ Entries defined in ``beat_schedule`` come back at the next beat restart;
 entries created through the API are gone for good. So RedBeat's keys must
 never expire, and the Redis holding them must never evict them.
 
-Two ways deployments break that:
+With ``maxmemory`` set and a ``maxmemory-policy`` in the ``allkeys-*`` family,
+Redis may drop any key once memory runs short, the schedule included. Use the
+``noeviction`` policy, or give RedBeat a Redis instance or database of its
+own. The ``volatile-*`` policies only drop keys carrying an expiry, and the
+only expiry RedBeat sets is on ``redbeat::lock``, which is supposed to expire,
+that is what releases the lock when a beat process dies.
 
-* an eviction policy. With ``maxmemory`` set and a ``maxmemory-policy`` in
-  the ``allkeys-*`` family, Redis may drop any key, including the schedule,
-  once memory runs short. The ``volatile-*`` policies only drop keys carrying
-  an expiry.
-* an expiry on the keys themselves, usually housekeeping on a shared Redis,
-  or a ``redbeat:*`` sweep modelled on the lock key.
-
-Use the ``noeviction`` policy, or give RedBeat a Redis instance or database
-of its own. ``redbeat::lock`` is the one deliberate exception: it is supposed
-to expire, that is what releases the lock when a beat process dies.
-
-At startup RedBeat checks what it can afford to check: whether
-``redbeat::schedule`` or ``redbeat::statics`` carry an expiry, and whether
-the server reports an evicting ``maxmemory-policy``. Findings are logged and
-repeated in the beat banner, under the control of ``redbeat_key_expiry_check``
-above. It does not walk the individual entry hashes, which would cost a round
-trip per entry on every beat startup. To check those by hand::
+At startup RedBeat reads ``maxmemory-policy`` and reports an evicting one,
+in the log and in the beat banner, under the control of
+``redbeat_key_expiry_check`` above. That single ``CONFIG GET`` is the whole
+check: RedBeat does not read back the expiry on its own keys, which would
+mean a round trip per entry on every start. If something in your deployment
+applies expiries to ``redbeat:*``, look for them yourself::
 
     redis-cli --scan --pattern 'redbeat:*' | while read key; do
         ttl=$(redis-cli ttl "$key")
         test "$ttl" -ge 0 && echo "$key expires in ${ttl}s"
     done
 
-The startup check needs no more than ``CONFIG GET``, and quietly skips the
-policy half when the server refuses it, as several managed Redis offerings
-do. A server RedBeat cannot ask is never reported as unsafe, so on those
-deployments check ``maxmemory-policy`` yourself through the provider console.
+Several managed Redis offerings disable or rename ``CONFIG``. RedBeat logs
+that it could not read the policy and starts anyway, even in ``'raise'``
+mode: a server it cannot ask is not a server it calls unsafe. Check
+``maxmemory-policy`` through the provider console instead.
 
 Programs that create entries through the API without running beat never reach
-the startup check, since it is beat that runs it.
+the check, since it runs when the scheduler is built.

--- a/redbeat/__init__.py
+++ b/redbeat/__init__.py
@@ -1,1 +1,2 @@
+from .checks import RedBeatKeyExpiryError  # noqa
 from .schedulers import RedBeatScheduler, RedBeatSchedulerEntry  # noqa

--- a/redbeat/checks.py
+++ b/redbeat/checks.py
@@ -28,8 +28,17 @@ def check_key_expiry(client, mode=DEFAULT_KEY_EXPIRY_CHECK):
     if mode == 'ignore':
         return []
 
-    strict = mode == 'raise'
-    findings = _find_evictable_policies(client, strict)
+    try:
+        config = client.config_get('maxmemory*')
+    except redis.exceptions.RedisError as exc:
+        message = 'could not read the Redis maxmemory policy: %s' % exc
+        if mode == 'raise':
+            raise RedBeatKeyExpiryError(message)
+
+        logger.warning('beat: %s', message)
+        return []
+
+    findings = _find_evictable_policies(config)
     if not findings:
         return []
 
@@ -37,21 +46,13 @@ def check_key_expiry(client, mode=DEFAULT_KEY_EXPIRY_CHECK):
     for finding in findings:
         log('beat: %s', finding)
 
-    if strict:
+    if mode == 'raise':
         raise RedBeatKeyExpiryError('; '.join(findings))
 
     return findings
 
 
-def _find_evictable_policies(client, strict=False):
-    try:
-        config = client.config_get('maxmemory*')
-    except redis.exceptions.RedisError as exc:
-        # a server we cannot ask is not a server we call unsafe
-        log = logger.error if strict else logger.warning
-        log('beat: could not read the Redis maxmemory policy: %s', exc)
-        return []
-
+def _find_evictable_policies(config):
     evicting = {}
     for node, node_config in _per_node(config):
         try:

--- a/redbeat/checks.py
+++ b/redbeat/checks.py
@@ -1,0 +1,94 @@
+# Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Copyright 2015 Marc Sibson
+
+
+import redis.exceptions
+from celery.utils.log import get_logger
+
+logger = get_logger('celery.beat')
+
+KEY_EXPIRY_CHECK_MODES = ('ignore', 'warn', 'error', 'raise')
+DEFAULT_KEY_EXPIRY_CHECK = 'error'
+
+EVICTABLE_MESSAGE = (
+    "Redis%s is configured with maxmemory %s and maxmemory-policy '%s', which lets "
+    "RedBeat's keys be evicted, silently stopping scheduled tasks; use the "
+    "'noeviction' policy or give RedBeat a Redis instance or db of its own"
+)
+
+
+class RedBeatKeyExpiryError(RuntimeError):
+    """Redis is configured to let RedBeat's keys be evicted."""
+
+
+def check_key_expiry(client, mode=DEFAULT_KEY_EXPIRY_CHECK):
+    """Report Redis configuration that lets RedBeat's keys disappear."""
+    if mode == 'ignore':
+        return []
+
+    strict = mode == 'raise'
+    findings = _find_evictable_policies(client, strict)
+    if not findings:
+        return []
+
+    log = logger.warning if mode == 'warn' else logger.error
+    for finding in findings:
+        log('beat: %s', finding)
+
+    if strict:
+        raise RedBeatKeyExpiryError('; '.join(findings))
+
+    return findings
+
+
+def _find_evictable_policies(client, strict=False):
+    try:
+        config = client.config_get('maxmemory*')
+    except redis.exceptions.RedisError as exc:
+        # a server we cannot ask is not a server we call unsafe
+        log = logger.error if strict else logger.warning
+        log('beat: could not read the Redis maxmemory policy: %s', exc)
+        return []
+
+    evicting = {}
+    for node, node_config in _per_node(config):
+        try:
+            maxmemory = int(node_config.get('maxmemory') or 0)
+        except (AttributeError, TypeError, ValueError):
+            continue
+
+        if not maxmemory:
+            # without a memory limit nothing is ever evicted, whatever the policy
+            continue
+
+        # volatile-* is safe, it only evicts keys carrying an expiry and the
+        # lock, which is meant to expire, is the only RedBeat key that has one
+        policy = (node_config.get('maxmemory-policy') or '').lower()
+        if policy.startswith('allkeys'):
+            evicting.setdefault((maxmemory, policy), []).append(node)
+
+    return [
+        EVICTABLE_MESSAGE % (_describe(nodes), maxmemory, policy)
+        for (maxmemory, policy), nodes in evicting.items()
+    ]
+
+
+def _per_node(config):
+    # a cluster client answers CONFIG GET with a reply per node
+    if not isinstance(config, dict) or not config:
+        return []
+
+    if all(isinstance(value, dict) for value in config.values()):
+        return sorted(config.items())
+
+    return [('', config)]
+
+
+def _describe(nodes):
+    names = sorted(node for node in nodes if node)
+    if not names:
+        return ''
+
+    return ' on node{} {}'.format('s' if len(names) > 1 else '', ', '.join(names))

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -278,12 +278,9 @@ def check_key_expiry(app=None):
 
 def _find_evictable_policies(client):
     try:
-        # a glob, supported by every server since 2.0, rather than CONFIG GET
-        # with several parameters, which needs Redis 7.0
         config = client.config_get('maxmemory*')
     except redis.exceptions.RedisError as exc:
-        # CONFIG is disabled or renamed on several managed Redis offerings,
-        # and a server we cannot ask is not a server we call unsafe
+        # a server we cannot ask is not a server we call unsafe
         logger.warning('beat: could not read the Redis maxmemory policy: %s', exc)
         return []
 
@@ -298,8 +295,8 @@ def _find_evictable_policies(client):
             # without a memory limit nothing is ever evicted, whatever the policy
             continue
 
-        # volatile-* only evicts keys carrying an expiry, and RedBeat sets one
-        # on the lock alone, which is meant to expire
+        # volatile-* is safe, it only evicts keys carrying an expiry and the
+        # lock, which is meant to expire, is the only RedBeat key that has one
         policy = (node_config.get('maxmemory-policy') or '').lower()
         if policy.startswith('allkeys'):
             findings.append(EVICTABLE_MESSAGE % (label, maxmemory, policy))
@@ -587,7 +584,6 @@ class RedBeatScheduler(Scheduler):
     #: The default lock timeout in seconds.
     lock_timeout = DEFAULT_MAX_INTERVAL * 5
 
-    #: Redis expiry problems found at startup, reported in the beat banner.
     key_expiry_findings = ()
 
     def __init__(self, app, lock_key=None, lock_timeout=None, **kwargs):

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -22,6 +22,7 @@ from redis import Redis
 from redis.sentinel import MasterNotFoundError, Sentinel
 from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_exponential
 
+from .checks import DEFAULT_KEY_EXPIRY_CHECK, KEY_EXPIRY_CHECK_MODES, check_key_expiry
 from .decoder import RedBeatJSONDecoder, RedBeatJSONEncoder, to_timestamp
 
 logger = get_logger('celery.beat')
@@ -235,84 +236,6 @@ ADD_ENTRY_ERROR = """\
 
 Couldn't add entry %r to redis schedule: %r. Contents: %r
 """
-
-
-KEY_EXPIRY_CHECK_MODES = ('ignore', 'warn', 'error', 'raise')
-DEFAULT_KEY_EXPIRY_CHECK = 'error'
-
-EVICTABLE_MESSAGE = (
-    "Redis%s is configured with maxmemory %s and maxmemory-policy '%s', which lets "
-    "RedBeat's keys be evicted, silently stopping scheduled tasks; use the "
-    "'noeviction' policy or give RedBeat a Redis instance or db of its own"
-)
-
-
-class RedBeatKeyExpiryError(RuntimeError):
-    """Redis is configured to let RedBeat's keys be evicted."""
-
-
-def check_key_expiry(app=None):
-    """Report Redis configuration that lets RedBeat's keys disappear."""
-    app = app_or_default(app)
-    conf = ensure_conf(app)
-    if conf.key_expiry_check == 'ignore':
-        return []
-
-    findings = _find_evictable_policies(get_redis(app))
-    if not findings:
-        return []
-
-    if conf.key_expiry_check == 'warn':
-        log = logger.warning
-    else:
-        log = logger.error
-
-    for finding in findings:
-        log('beat: %s', finding)
-
-    if conf.key_expiry_check == 'raise':
-        raise RedBeatKeyExpiryError('; '.join(findings))
-
-    return findings
-
-
-def _find_evictable_policies(client):
-    try:
-        config = client.config_get('maxmemory*')
-    except redis.exceptions.RedisError as exc:
-        # a server we cannot ask is not a server we call unsafe
-        logger.warning('beat: could not read the Redis maxmemory policy: %s', exc)
-        return []
-
-    findings = []
-    for label, node_config in _per_node(config):
-        try:
-            maxmemory = int(node_config.get('maxmemory') or 0)
-        except (AttributeError, TypeError, ValueError):
-            continue
-
-        if not maxmemory:
-            # without a memory limit nothing is ever evicted, whatever the policy
-            continue
-
-        # volatile-* is safe, it only evicts keys carrying an expiry and the
-        # lock, which is meant to expire, is the only RedBeat key that has one
-        policy = (node_config.get('maxmemory-policy') or '').lower()
-        if policy.startswith('allkeys'):
-            findings.append(EVICTABLE_MESSAGE % (label, maxmemory, policy))
-
-    return findings
-
-
-def _per_node(config):
-    # a cluster client answers CONFIG GET with a reply per node
-    if not isinstance(config, dict) or not config:
-        return []
-
-    if all(isinstance(value, dict) for value in config.values()):
-        return [(' on node {}'.format(node), values) for node, values in config.items()]
-
-    return [('', config)]
 
 
 class RedBeatConfig:
@@ -597,7 +520,9 @@ class RedBeatScheduler(Scheduler):
             or self.max_interval * 5
             or self.lock_timeout
         )
-        self.key_expiry_findings = check_key_expiry(self.app)
+        self.key_expiry_findings = check_key_expiry(
+            get_redis(self.app), app.redbeat_conf.key_expiry_check
+        )
 
     def setup_schedule(self):
         # cleanup old static schedule entries

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -240,45 +240,25 @@ Couldn't add entry %r to redis schedule: %r. Contents: %r
 KEY_EXPIRY_CHECK_MODES = ('ignore', 'warn', 'error', 'raise')
 DEFAULT_KEY_EXPIRY_CHECK = 'error'
 
-EXPIRING_KEY_MESSAGE = (
-    "%s has an expiry set (%s), RedBeat's keys hold the schedule itself "
-    "and must never expire"
-)
 EVICTABLE_MESSAGE = (
     "Redis%s is configured with maxmemory %s and maxmemory-policy '%s', which lets "
     "RedBeat's keys be evicted, silently stopping scheduled tasks; use the "
     "'noeviction' policy or give RedBeat a Redis instance or db of its own"
 )
-VOLATILE_MESSAGE = (
-    "Redis%s is configured with maxmemory %s and maxmemory-policy '%s', which evicts "
-    "keys that carry an expiry, and RedBeat keys with an expiry were found; use the "
-    "'noeviction' policy or give RedBeat a Redis instance or db of its own"
-)
 
 
 class RedBeatKeyExpiryError(RuntimeError):
-    """Redis is configured to let RedBeat's keys expire or be evicted."""
+    """Redis is configured to let RedBeat's keys be evicted."""
 
 
 def check_key_expiry(app=None):
-    """Report Redis configuration that lets RedBeat's keys disappear.
-
-    Runs two O(1) checks against the keys RedBeat owns: an expiry on the
-    schedule and statics keys, and a maxmemory policy that can evict them.
-    Individual entry hashes are deliberately not inspected, that would cost a
-    round trip per entry, see the docs for a redis-cli recipe.
-
-    Returns the findings as a list of strings, empty when nothing is wrong,
-    when the check is disabled, or when Redis would not answer.
-    """
+    """Report Redis configuration that lets RedBeat's keys disappear."""
     app = app_or_default(app)
     conf = ensure_conf(app)
     if conf.key_expiry_check == 'ignore':
         return []
 
-    client = get_redis(app)
-    findings = _find_expiring_keys(client, conf)
-    findings.extend(_find_evictable_policies(client, bool(findings)))
+    findings = _find_evictable_policies(get_redis(app))
     if not findings:
         return []
 
@@ -296,41 +276,15 @@ def check_key_expiry(app=None):
     return findings
 
 
-def _find_expiring_keys(client, conf):
-    """Look for an expiry on the keys holding the schedule.
-
-    The lock key is skipped, it is meant to expire.
-    """
-    keys = [conf.schedule_key, conf.statics_key]
+def _find_evictable_policies(client):
     try:
-        with client.pipeline() as pipe:
-            for key in keys:
-                pipe.pttl(key)
-            ttls = pipe.execute()
-    except redis.exceptions.RedisError as exc:
-        logger.debug('beat: could not check RedBeat keys for an expiry: %s', exc)
-        return []
-
-    # pttl answers -1 for a key without an expiry and -2 for a missing one
-    return [
-        EXPIRING_KEY_MESSAGE % (key, humanize_seconds(ttl / 1000.0))
-        for key, ttl in zip(keys, ttls)
-        if isinstance(ttl, int) and ttl >= 0
-    ]
-
-
-def _find_evictable_policies(client, keys_expire):
-    """Look for a maxmemory policy that can evict RedBeat's keys.
-
-    CONFIG is disabled or renamed on several managed Redis offerings, so
-    failing to read it is not a finding: unknown never means unsafe.
-    """
-    try:
-        # a glob, rather than CONFIG GET with several parameters, which needs
-        # Redis 7.0; a cluster client answers per node
+        # a glob, supported by every server since 2.0, rather than CONFIG GET
+        # with several parameters, which needs Redis 7.0
         config = client.config_get('maxmemory*')
     except redis.exceptions.RedisError as exc:
-        logger.debug('beat: could not read the Redis maxmemory policy: %s', exc)
+        # CONFIG is disabled or renamed on several managed Redis offerings,
+        # and a server we cannot ask is not a server we call unsafe
+        logger.warning('beat: could not read the Redis maxmemory policy: %s', exc)
         return []
 
     findings = []
@@ -340,24 +294,21 @@ def _find_evictable_policies(client, keys_expire):
         except (AttributeError, TypeError, ValueError):
             continue
 
-        policy = (node_config.get('maxmemory-policy') or '').lower()
         if not maxmemory:
             # without a memory limit nothing is ever evicted, whatever the policy
             continue
 
+        # volatile-* only evicts keys carrying an expiry, and RedBeat sets one
+        # on the lock alone, which is meant to expire
+        policy = (node_config.get('maxmemory-policy') or '').lower()
         if policy.startswith('allkeys'):
             findings.append(EVICTABLE_MESSAGE % (label, maxmemory, policy))
-        elif policy.startswith('volatile') and keys_expire:
-            findings.append(VOLATILE_MESSAGE % (label, maxmemory, policy))
 
     return findings
 
 
 def _per_node(config):
-    """Normalise a CONFIG GET reply into (label, config) pairs.
-
-    A cluster client answers with a dict of replies keyed by node.
-    """
+    # a cluster client answers CONFIG GET with a reply per node
     if not isinstance(config, dict) or not config:
         return []
 
@@ -650,12 +601,9 @@ class RedBeatScheduler(Scheduler):
             or self.max_interval * 5
             or self.lock_timeout
         )
-
-    def setup_schedule(self):
-        # a schedule that Redis is free to drop is worth saying out loud, and
-        # saying it once at startup rather than per tick
         self.key_expiry_findings = check_key_expiry(self.app)
 
+    def setup_schedule(self):
         # cleanup old static schedule entries
         client = get_redis(self.app)
         previous = {key for key in client.smembers(self.app.redbeat_conf.statics_key)}

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -237,6 +237,136 @@ Couldn't add entry %r to redis schedule: %r. Contents: %r
 """
 
 
+KEY_EXPIRY_CHECK_MODES = ('ignore', 'warn', 'error', 'raise')
+DEFAULT_KEY_EXPIRY_CHECK = 'error'
+
+EXPIRING_KEY_MESSAGE = (
+    "%s has an expiry set (%s), RedBeat's keys hold the schedule itself "
+    "and must never expire"
+)
+EVICTABLE_MESSAGE = (
+    "Redis%s is configured with maxmemory %s and maxmemory-policy '%s', which lets "
+    "RedBeat's keys be evicted, silently stopping scheduled tasks; use the "
+    "'noeviction' policy or give RedBeat a Redis instance or db of its own"
+)
+VOLATILE_MESSAGE = (
+    "Redis%s is configured with maxmemory %s and maxmemory-policy '%s', which evicts "
+    "keys that carry an expiry, and RedBeat keys with an expiry were found; use the "
+    "'noeviction' policy or give RedBeat a Redis instance or db of its own"
+)
+
+
+class RedBeatKeyExpiryError(RuntimeError):
+    """Redis is configured to let RedBeat's keys expire or be evicted."""
+
+
+def check_key_expiry(app=None):
+    """Report Redis configuration that lets RedBeat's keys disappear.
+
+    Runs two O(1) checks against the keys RedBeat owns: an expiry on the
+    schedule and statics keys, and a maxmemory policy that can evict them.
+    Individual entry hashes are deliberately not inspected, that would cost a
+    round trip per entry, see the docs for a redis-cli recipe.
+
+    Returns the findings as a list of strings, empty when nothing is wrong,
+    when the check is disabled, or when Redis would not answer.
+    """
+    app = app_or_default(app)
+    conf = ensure_conf(app)
+    if conf.key_expiry_check == 'ignore':
+        return []
+
+    client = get_redis(app)
+    findings = _find_expiring_keys(client, conf)
+    findings.extend(_find_evictable_policies(client, bool(findings)))
+    if not findings:
+        return []
+
+    if conf.key_expiry_check == 'warn':
+        log = logger.warning
+    else:
+        log = logger.error
+
+    for finding in findings:
+        log('beat: %s', finding)
+
+    if conf.key_expiry_check == 'raise':
+        raise RedBeatKeyExpiryError('; '.join(findings))
+
+    return findings
+
+
+def _find_expiring_keys(client, conf):
+    """Look for an expiry on the keys holding the schedule.
+
+    The lock key is skipped, it is meant to expire.
+    """
+    keys = [conf.schedule_key, conf.statics_key]
+    try:
+        with client.pipeline() as pipe:
+            for key in keys:
+                pipe.pttl(key)
+            ttls = pipe.execute()
+    except redis.exceptions.RedisError as exc:
+        logger.debug('beat: could not check RedBeat keys for an expiry: %s', exc)
+        return []
+
+    # pttl answers -1 for a key without an expiry and -2 for a missing one
+    return [
+        EXPIRING_KEY_MESSAGE % (key, humanize_seconds(ttl / 1000.0))
+        for key, ttl in zip(keys, ttls)
+        if isinstance(ttl, int) and ttl >= 0
+    ]
+
+
+def _find_evictable_policies(client, keys_expire):
+    """Look for a maxmemory policy that can evict RedBeat's keys.
+
+    CONFIG is disabled or renamed on several managed Redis offerings, so
+    failing to read it is not a finding: unknown never means unsafe.
+    """
+    try:
+        # a glob, rather than CONFIG GET with several parameters, which needs
+        # Redis 7.0; a cluster client answers per node
+        config = client.config_get('maxmemory*')
+    except redis.exceptions.RedisError as exc:
+        logger.debug('beat: could not read the Redis maxmemory policy: %s', exc)
+        return []
+
+    findings = []
+    for label, node_config in _per_node(config):
+        try:
+            maxmemory = int(node_config.get('maxmemory') or 0)
+        except (AttributeError, TypeError, ValueError):
+            continue
+
+        policy = (node_config.get('maxmemory-policy') or '').lower()
+        if not maxmemory:
+            # without a memory limit nothing is ever evicted, whatever the policy
+            continue
+
+        if policy.startswith('allkeys'):
+            findings.append(EVICTABLE_MESSAGE % (label, maxmemory, policy))
+        elif policy.startswith('volatile') and keys_expire:
+            findings.append(VOLATILE_MESSAGE % (label, maxmemory, policy))
+
+    return findings
+
+
+def _per_node(config):
+    """Normalise a CONFIG GET reply into (label, config) pairs.
+
+    A cluster client answers with a dict of replies keyed by node.
+    """
+    if not isinstance(config, dict) or not config:
+        return []
+
+    if all(isinstance(value, dict) for value in config.values()):
+        return [(' on node {}'.format(node), values) for node, values in config.items()]
+
+    return [('', config)]
+
+
 class RedBeatConfig:
     def __init__(self, app=None):
         self.app = app_or_default(app)
@@ -268,6 +398,30 @@ class RedBeatConfig:
         if self.lock_key and not self.lock_key.startswith(self.key_prefix):
             self.lock_key = self.key_prefix + self.lock_key
         self.lock_timeout = self.either_or('redbeat_lock_timeout', None)
+        self.key_expiry_check = self._key_expiry_check_mode()
+
+    def _key_expiry_check_mode(self):
+        configured = self.either_or('redbeat_key_expiry_check', DEFAULT_KEY_EXPIRY_CHECK)
+        try:
+            mode = configured.lower()
+        except AttributeError:
+            mode = None
+
+        if mode not in KEY_EXPIRY_CHECK_MODES:
+            message = (
+                'Ignoring unknown redbeat_key_expiry_check %r, using %r; '
+                'valid values are %s'
+                % (
+                    configured,
+                    DEFAULT_KEY_EXPIRY_CHECK,
+                    ', '.join(repr(m) for m in KEY_EXPIRY_CHECK_MODES),
+                )
+            )
+            warnings.warn(message, UserWarning, stacklevel=2)
+            logger.warning('beat: %s', message)
+            mode = DEFAULT_KEY_EXPIRY_CHECK
+
+        return mode
 
     @property
     def schedule(self):
@@ -482,6 +636,9 @@ class RedBeatScheduler(Scheduler):
     #: The default lock timeout in seconds.
     lock_timeout = DEFAULT_MAX_INTERVAL * 5
 
+    #: Redis expiry problems found at startup, reported in the beat banner.
+    key_expiry_findings = ()
+
     def __init__(self, app, lock_key=None, lock_timeout=None, **kwargs):
         ensure_conf(app)  # set app.redbeat_conf
         super(RedBeatScheduler, self).__init__(app, **kwargs)
@@ -495,6 +652,10 @@ class RedBeatScheduler(Scheduler):
         )
 
     def setup_schedule(self):
+        # a schedule that Redis is free to drop is worth saying out loud, and
+        # saying it once at startup rather than per tick
+        self.key_expiry_findings = check_key_expiry(self.app)
+
         # cleanup old static schedule entries
         client = get_redis(self.app)
         previous = {key for key in client.smembers(self.app.redbeat_conf.statics_key)}
@@ -565,7 +726,11 @@ class RedBeatScheduler(Scheduler):
             try:
                 entry = self.Entry.from_key(key, app=self.app)
             except KeyError:
-                logger.error('beat: Failed to load %s, removing', key)
+                logger.error(
+                    'beat: Failed to load %s, removing; its hash is gone, which usually '
+                    'means Redis evicted or expired it',
+                    key,
+                )
                 client.zrem(self.app.redbeat_conf.schedule_key, key)
                 continue
 
@@ -622,6 +787,8 @@ class RedBeatScheduler(Scheduler):
                     self.lock_key, humanize_seconds(self.lock_timeout), self.lock_timeout
                 )
             )
+        for finding in self.key_expiry_findings:
+            info.append('       . WARNING -> {}'.format(finding))
         return '\n'.join(info)
 
     @cached_property

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -67,7 +67,7 @@ class test_key_expiry_check(TestCase):
 class test_unreadable_config(TestCase):
     def test_is_not_a_finding(self):
         with self.assertLogs('celery.beat', level='WARNING'):
-            self.assertEqual(check_key_expiry(unreadable_client(), 'raise'), [])
+            self.assertEqual(check_key_expiry(unreadable_client()), [])
 
     def test_is_logged_as_a_warning(self):
         with self.assertLogs('celery.beat', level='WARNING') as cm:
@@ -75,11 +75,11 @@ class test_unreadable_config(TestCase):
 
         self.assertTrue(all(record.startswith('WARNING') for record in cm.output))
 
-    def test_is_logged_as_an_error_in_raise_mode(self):
-        with self.assertLogs('celery.beat', level='ERROR') as cm:
+    def test_raises_in_raise_mode(self):
+        # asking to be strict about eviction means being strict about not
+        # knowing whether keys can be evicted
+        with self.assertRaises(RedBeatKeyExpiryError):
             check_key_expiry(unreadable_client(), 'raise')
-
-        self.assertTrue(any('maxmemory policy' in message for message in cm.output))
 
 
 class test_cluster_config(TestCase):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,108 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from redis.exceptions import ResponseError
+
+from redbeat.checks import RedBeatKeyExpiryError, check_key_expiry
+
+
+def client(maxmemory=0, policy='noeviction', config=None):
+    if config is None:
+        config = {'maxmemory': str(maxmemory), 'maxmemory-policy': policy}
+
+    return Mock(config_get=Mock(return_value=config))
+
+
+def unreadable_client():
+    return Mock(config_get=Mock(side_effect=ResponseError("unknown command 'config get'")))
+
+
+class test_key_expiry_check(TestCase):
+    def test_nothing_to_report_by_default(self):
+        self.assertEqual(check_key_expiry(client()), [])
+
+    def test_evicting_policy_is_reported(self):
+        findings = check_key_expiry(client(maxmemory=100000, policy='allkeys-lru'))
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn('allkeys-lru', findings[0])
+
+    def test_evicting_policy_without_a_memory_limit_is_ignored(self):
+        self.assertEqual(check_key_expiry(client(maxmemory=0, policy='allkeys-lru')), [])
+
+    def test_volatile_policy_is_ignored(self):
+        self.assertEqual(check_key_expiry(client(maxmemory=100000, policy='volatile-lru')), [])
+
+    def test_unparsable_maxmemory_is_ignored(self):
+        config = {'maxmemory': 'lots', 'maxmemory-policy': 'allkeys-lru'}
+
+        self.assertEqual(check_key_expiry(client(config=config)), [])
+
+    def test_findings_are_logged_as_errors(self):
+        with self.assertLogs('celery.beat', level='ERROR') as cm:
+            check_key_expiry(client(maxmemory=100000, policy='allkeys-lru'))
+
+        self.assertTrue(any('allkeys-lru' in message for message in cm.output))
+
+    def test_warn_mode_logs_a_warning(self):
+        with self.assertLogs('celery.beat', level='WARNING') as cm:
+            check_key_expiry(client(maxmemory=100000, policy='allkeys-lru'), 'warn')
+
+        self.assertTrue(all(record.startswith('WARNING') for record in cm.output))
+
+    def test_raise_mode_raises(self):
+        with self.assertRaises(RedBeatKeyExpiryError):
+            check_key_expiry(client(maxmemory=100000, policy='allkeys-lru'), 'raise')
+
+    def test_raise_mode_is_quiet_when_nothing_is_wrong(self):
+        self.assertEqual(check_key_expiry(client(), 'raise'), [])
+
+    def test_ignore_mode_asks_redis_nothing(self):
+        redis = client(maxmemory=100000, policy='allkeys-lru')
+
+        self.assertEqual(check_key_expiry(redis, 'ignore'), [])
+        self.assertFalse(redis.config_get.called)
+
+
+class test_unreadable_config(TestCase):
+    def test_is_not_a_finding(self):
+        with self.assertLogs('celery.beat', level='WARNING'):
+            self.assertEqual(check_key_expiry(unreadable_client(), 'raise'), [])
+
+    def test_is_logged_as_a_warning(self):
+        with self.assertLogs('celery.beat', level='WARNING') as cm:
+            check_key_expiry(unreadable_client())
+
+        self.assertTrue(all(record.startswith('WARNING') for record in cm.output))
+
+    def test_is_logged_as_an_error_in_raise_mode(self):
+        with self.assertLogs('celery.beat', level='ERROR') as cm:
+            check_key_expiry(unreadable_client(), 'raise')
+
+        self.assertTrue(any('maxmemory policy' in message for message in cm.output))
+
+
+class test_cluster_config(TestCase):
+    def config(self, *policies):
+        return {
+            'node-{}'.format(number): {'maxmemory': '100000', 'maxmemory-policy': policy}
+            for number, policy in enumerate(policies, start=1)
+        }
+
+    def test_reply_is_reported_per_node(self):
+        findings = check_key_expiry(client(config=self.config('noeviction', 'allkeys-lfu')))
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn('on node node-2', findings[0])
+        self.assertIn('allkeys-lfu', findings[0])
+
+    def test_nodes_sharing_a_policy_are_reported_once(self):
+        findings = check_key_expiry(client(config=self.config('allkeys-lru', 'allkeys-lru')))
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn('on nodes node-1, node-2', findings[0])
+
+    def test_differing_policies_are_reported_separately(self):
+        findings = check_key_expiry(client(config=self.config('allkeys-lru', 'allkeys-lfu')))
+
+        self.assertEqual(len(findings), 2)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,24 @@ class test_RedBeatConfig(AppCase):
         self.conf = RedBeatConfig(self.app)
         self.assertEqual(self.conf.lock_key, 'redbeat::custom')
 
+    def test_key_expiry_check_default(self):
+        self.assertEqual(self.conf.key_expiry_check, 'error')
+
+    def test_key_expiry_check_override(self):
+        self.app.conf.redbeat_key_expiry_check = 'RAISE'
+        self.conf = RedBeatConfig(self.app)
+        self.assertEqual(self.conf.key_expiry_check, 'raise')
+
+    def test_key_expiry_check_unknown_value_falls_back_to_the_default(self):
+        self.app.conf.redbeat_key_expiry_check = 'shout'
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.conf = RedBeatConfig(self.app)
+
+        self.assertEqual(self.conf.key_expiry_check, 'error')
+        self.assertTrue(any("'shout'" in str(w.message) for w in caught))
+
     def test_schedule(self):
         schedule = {'foo': 'bar'}
         self.conf.schedule = schedule

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -708,8 +708,8 @@ class test_key_expiry_check(RedBeatCase):
         self.redis = self.app.redbeat_redis
 
     def check(self, maxmemory=None, policy=None, mode=None):
-        # fakeredis has no CONFIG GET, so the reply is stubbed; passing neither
-        # setting leaves it raising, the same as a Redis that hides CONFIG
+        # fakeredis has no CONFIG GET, so a reply is stubbed in; passing no
+        # settings leaves it raising, as a Redis that hides CONFIG does
         if mode is not None:
             self.conf.key_expiry_check = mode
 
@@ -730,12 +730,9 @@ class test_key_expiry_check(RedBeatCase):
         self.assertIn('allkeys-lru', findings[0])
 
     def test_evicting_policy_without_a_memory_limit_is_ignored(self):
-        # eviction never triggers while maxmemory is 0, whatever the policy
         self.assertEqual(self.check(maxmemory=0, policy='allkeys-lru'), [])
 
     def test_volatile_policy_is_ignored(self):
-        # volatile-* only evicts keys carrying an expiry, and the lock is the
-        # only RedBeat key that has one
         self.assertEqual(self.check(maxmemory=100000, policy='volatile-lru'), [])
 
     def test_findings_are_logged_as_errors(self):
@@ -764,8 +761,6 @@ class test_key_expiry_check(RedBeatCase):
         self.assertFalse(config_get.called)
 
     def test_unreadable_config_is_not_a_finding(self):
-        # CONFIG is disabled or renamed on several managed Redis offerings;
-        # fakeredis rejects it too, which is what self.check() leaves in place
         with self.assertRaises(ResponseError):
             self.redis.config_get('maxmemory*')
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,13 +10,15 @@ from celery.beat import DEFAULT_MAX_INTERVAL
 from celery.schedules import schedstate, schedule
 from celery.utils.time import maybe_timedelta
 from redis import CredentialProvider
-from redis.exceptions import ConnectionError
+from redis.exceptions import ConnectionError, ResponseError
 
 from redbeat import RedBeatScheduler
 from redbeat.schedulers import (
+    RedBeatKeyExpiryError,
     RedBeatSchedulerEntry,
     RetryingConnection,
     acquire_distributed_beat_lock,
+    check_key_expiry,
     ensure_conf,
     get_redis,
 )
@@ -697,3 +699,152 @@ class RedBeatStartupAcquiresLock(RedBeatSchedulerTestBase):
 
         self.assertIsNone(self.s.lock)
         self.assertIsNone(get_redis(app=self.app).get(self.s.lock_key))
+
+
+class test_key_expiry_check(RedBeatCase):
+    def setup(self):
+        super().setup()
+        self.conf = ensure_conf(self.app)
+        self.redis = self.app.redbeat_redis
+
+    def check(self, maxmemory=None, policy=None, mode=None):
+        """Run the check with Redis reporting the given maxmemory settings.
+
+        fakeredis has no CONFIG GET, so the reply is stubbed; passing neither
+        setting leaves it raising, the same as a Redis that hides CONFIG.
+        """
+        if mode is not None:
+            self.conf.key_expiry_check = mode
+
+        if maxmemory is None and policy is None:
+            return check_key_expiry(self.app)
+
+        config = {'maxmemory': str(maxmemory), 'maxmemory-policy': policy}
+        with patch.object(self.redis, 'config_get', return_value=config):
+            return check_key_expiry(self.app)
+
+    def test_nothing_to_report_by_default(self):
+        self.assertEqual(self.check(maxmemory=0, policy='noeviction'), [])
+
+    def test_evicting_policy_is_reported(self):
+        findings = self.check(maxmemory=100000, policy='allkeys-lru')
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn('allkeys-lru', findings[0])
+
+    def test_evicting_policy_without_a_memory_limit_is_ignored(self):
+        # eviction never triggers while maxmemory is 0, whatever the policy
+        self.assertEqual(self.check(maxmemory=0, policy='allkeys-lru'), [])
+
+    def test_volatile_policy_alone_is_ignored(self):
+        # volatile-* only evicts keys carrying an expiry, and ours carry none
+        self.assertEqual(self.check(maxmemory=100000, policy='volatile-lru'), [])
+
+    def test_volatile_policy_with_an_expiring_key_is_reported(self):
+        self.create_entry().save()
+        self.redis.expire(self.conf.schedule_key, 300)
+
+        findings = self.check(maxmemory=100000, policy='volatile-lru')
+
+        self.assertEqual(len(findings), 2)
+        self.assertIn(self.conf.schedule_key, findings[0])
+        self.assertIn('volatile-lru', findings[1])
+
+    def test_expiry_on_the_schedule_key_is_reported(self):
+        self.create_entry().save()
+        self.redis.expire(self.conf.schedule_key, 300)
+
+        findings = self.check()
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn(self.conf.schedule_key, findings[0])
+
+    def test_expiry_on_the_statics_key_is_reported(self):
+        self.redis.sadd(self.conf.statics_key, 'test')
+        self.redis.expire(self.conf.statics_key, 300)
+
+        findings = self.check()
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn(self.conf.statics_key, findings[0])
+
+    def test_expiry_on_the_lock_key_is_ignored(self):
+        # the lock is the one RedBeat key that is supposed to expire
+        self.redis.set(self.conf.lock_key, 'token', ex=300)
+
+        self.assertEqual(self.check(), [])
+
+    def test_findings_are_logged_as_errors(self):
+        self.redis.sadd(self.conf.statics_key, 'test')
+        self.redis.expire(self.conf.statics_key, 300)
+
+        with self.assertLogs('celery.beat', level='ERROR') as cm:
+            self.check()
+
+        self.assertTrue(any('must never expire' in message for message in cm.output))
+
+    def test_warn_mode_logs_a_warning(self):
+        self.redis.sadd(self.conf.statics_key, 'test')
+        self.redis.expire(self.conf.statics_key, 300)
+
+        with self.assertLogs('celery.beat', level='WARNING') as cm:
+            self.check(mode='warn')
+
+        self.assertTrue(all(record.startswith('WARNING') for record in cm.output))
+
+    def test_raise_mode_raises(self):
+        self.redis.sadd(self.conf.statics_key, 'test')
+        self.redis.expire(self.conf.statics_key, 300)
+
+        with self.assertRaises(RedBeatKeyExpiryError):
+            self.check(mode='raise')
+
+    def test_raise_mode_is_quiet_when_nothing_is_wrong(self):
+        self.assertEqual(self.check(maxmemory=0, policy='noeviction', mode='raise'), [])
+
+    def test_ignore_mode_asks_redis_nothing(self):
+        self.redis.sadd(self.conf.statics_key, 'test')
+        self.redis.expire(self.conf.statics_key, 300)
+
+        with patch.object(self.redis, 'pipeline') as pipeline:
+            self.assertEqual(self.check(mode='ignore'), [])
+
+        self.assertFalse(pipeline.called)
+
+    def test_unreadable_config_is_not_a_finding(self):
+        # CONFIG is disabled or renamed on several managed Redis offerings;
+        # fakeredis rejects it too, which is what self.check() leaves in place
+        with self.assertRaises(ResponseError):
+            self.redis.config_get('maxmemory*')
+
+        self.assertEqual(self.check(mode='raise'), [])
+
+    def test_cluster_config_reply_is_reported_per_node(self):
+        # a cluster client answers CONFIG GET with a reply per node
+        config = {
+            'node-1': {'maxmemory': '100000', 'maxmemory-policy': 'noeviction'},
+            'node-2': {'maxmemory': '100000', 'maxmemory-policy': 'allkeys-lfu'},
+        }
+        with patch.object(self.redis, 'config_get', return_value=config):
+            findings = check_key_expiry(self.app)
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn('node-2', findings[0])
+        self.assertIn('allkeys-lfu', findings[0])
+
+
+class test_key_expiry_check_at_startup(RedBeatSchedulerTestBase):
+    def test_findings_appear_in_the_beat_banner(self):
+        redis = self.app.redbeat_redis
+        redis.sadd(self.app.redbeat_conf.statics_key, 'test')
+        redis.expire(self.app.redbeat_conf.statics_key, 300)
+
+        self.s.setup_schedule()
+
+        self.assertIn('must never expire', self.s.info)
+
+    def test_banner_is_clean_when_nothing_is_wrong(self):
+        self.s.setup_schedule()
+
+        self.assertEqual(self.s.key_expiry_findings, [])
+        self.assertNotIn('WARNING', self.s.info)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -708,11 +708,8 @@ class test_key_expiry_check(RedBeatCase):
         self.redis = self.app.redbeat_redis
 
     def check(self, maxmemory=None, policy=None, mode=None):
-        """Run the check with Redis reporting the given maxmemory settings.
-
-        fakeredis has no CONFIG GET, so the reply is stubbed; passing neither
-        setting leaves it raising, the same as a Redis that hides CONFIG.
-        """
+        # fakeredis has no CONFIG GET, so the reply is stubbed; passing neither
+        # setting leaves it raising, the same as a Redis that hides CONFIG
         if mode is not None:
             self.conf.key_expiry_check = mode
 
@@ -736,80 +733,35 @@ class test_key_expiry_check(RedBeatCase):
         # eviction never triggers while maxmemory is 0, whatever the policy
         self.assertEqual(self.check(maxmemory=0, policy='allkeys-lru'), [])
 
-    def test_volatile_policy_alone_is_ignored(self):
-        # volatile-* only evicts keys carrying an expiry, and ours carry none
+    def test_volatile_policy_is_ignored(self):
+        # volatile-* only evicts keys carrying an expiry, and the lock is the
+        # only RedBeat key that has one
         self.assertEqual(self.check(maxmemory=100000, policy='volatile-lru'), [])
 
-    def test_volatile_policy_with_an_expiring_key_is_reported(self):
-        self.create_entry().save()
-        self.redis.expire(self.conf.schedule_key, 300)
-
-        findings = self.check(maxmemory=100000, policy='volatile-lru')
-
-        self.assertEqual(len(findings), 2)
-        self.assertIn(self.conf.schedule_key, findings[0])
-        self.assertIn('volatile-lru', findings[1])
-
-    def test_expiry_on_the_schedule_key_is_reported(self):
-        self.create_entry().save()
-        self.redis.expire(self.conf.schedule_key, 300)
-
-        findings = self.check()
-
-        self.assertEqual(len(findings), 1)
-        self.assertIn(self.conf.schedule_key, findings[0])
-
-    def test_expiry_on_the_statics_key_is_reported(self):
-        self.redis.sadd(self.conf.statics_key, 'test')
-        self.redis.expire(self.conf.statics_key, 300)
-
-        findings = self.check()
-
-        self.assertEqual(len(findings), 1)
-        self.assertIn(self.conf.statics_key, findings[0])
-
-    def test_expiry_on_the_lock_key_is_ignored(self):
-        # the lock is the one RedBeat key that is supposed to expire
-        self.redis.set(self.conf.lock_key, 'token', ex=300)
-
-        self.assertEqual(self.check(), [])
-
     def test_findings_are_logged_as_errors(self):
-        self.redis.sadd(self.conf.statics_key, 'test')
-        self.redis.expire(self.conf.statics_key, 300)
-
         with self.assertLogs('celery.beat', level='ERROR') as cm:
-            self.check()
+            self.check(maxmemory=100000, policy='allkeys-lru')
 
-        self.assertTrue(any('must never expire' in message for message in cm.output))
+        self.assertTrue(any('allkeys-lru' in message for message in cm.output))
 
     def test_warn_mode_logs_a_warning(self):
-        self.redis.sadd(self.conf.statics_key, 'test')
-        self.redis.expire(self.conf.statics_key, 300)
-
         with self.assertLogs('celery.beat', level='WARNING') as cm:
-            self.check(mode='warn')
+            self.check(maxmemory=100000, policy='allkeys-lru', mode='warn')
 
         self.assertTrue(all(record.startswith('WARNING') for record in cm.output))
 
     def test_raise_mode_raises(self):
-        self.redis.sadd(self.conf.statics_key, 'test')
-        self.redis.expire(self.conf.statics_key, 300)
-
         with self.assertRaises(RedBeatKeyExpiryError):
-            self.check(mode='raise')
+            self.check(maxmemory=100000, policy='allkeys-lru', mode='raise')
 
     def test_raise_mode_is_quiet_when_nothing_is_wrong(self):
         self.assertEqual(self.check(maxmemory=0, policy='noeviction', mode='raise'), [])
 
     def test_ignore_mode_asks_redis_nothing(self):
-        self.redis.sadd(self.conf.statics_key, 'test')
-        self.redis.expire(self.conf.statics_key, 300)
-
-        with patch.object(self.redis, 'pipeline') as pipeline:
+        with patch.object(self.redis, 'config_get') as config_get:
             self.assertEqual(self.check(mode='ignore'), [])
 
-        self.assertFalse(pipeline.called)
+        self.assertFalse(config_get.called)
 
     def test_unreadable_config_is_not_a_finding(self):
         # CONFIG is disabled or renamed on several managed Redis offerings;
@@ -817,10 +769,10 @@ class test_key_expiry_check(RedBeatCase):
         with self.assertRaises(ResponseError):
             self.redis.config_get('maxmemory*')
 
-        self.assertEqual(self.check(mode='raise'), [])
+        with self.assertLogs('celery.beat', level='WARNING'):
+            self.assertEqual(self.check(mode='raise'), [])
 
     def test_cluster_config_reply_is_reported_per_node(self):
-        # a cluster client answers CONFIG GET with a reply per node
         config = {
             'node-1': {'maxmemory': '100000', 'maxmemory-policy': 'noeviction'},
             'node-2': {'maxmemory': '100000', 'maxmemory-policy': 'allkeys-lfu'},
@@ -833,18 +785,18 @@ class test_key_expiry_check(RedBeatCase):
         self.assertIn('allkeys-lfu', findings[0])
 
 
-class test_key_expiry_check_at_startup(RedBeatSchedulerTestBase):
+class test_key_expiry_check_at_startup(RedBeatCase):
     def test_findings_appear_in_the_beat_banner(self):
-        redis = self.app.redbeat_redis
-        redis.sadd(self.app.redbeat_conf.statics_key, 'test')
-        redis.expire(self.app.redbeat_conf.statics_key, 300)
+        config = {'maxmemory': '100000', 'maxmemory-policy': 'allkeys-lru'}
+        with patch.object(self.app.redbeat_redis, 'config_get', return_value=config):
+            scheduler = RedBeatScheduler(app=self.app)
 
-        self.s.setup_schedule()
-
-        self.assertIn('must never expire', self.s.info)
+        self.assertIn('allkeys-lru', scheduler.info)
 
     def test_banner_is_clean_when_nothing_is_wrong(self):
-        self.s.setup_schedule()
+        config = {'maxmemory': '0', 'maxmemory-policy': 'noeviction'}
+        with patch.object(self.app.redbeat_redis, 'config_get', return_value=config):
+            scheduler = RedBeatScheduler(app=self.app)
 
-        self.assertEqual(self.s.key_expiry_findings, [])
-        self.assertNotIn('WARNING', self.s.info)
+        self.assertEqual(scheduler.key_expiry_findings, [])
+        self.assertNotIn('WARNING', scheduler.info)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,15 +10,13 @@ from celery.beat import DEFAULT_MAX_INTERVAL
 from celery.schedules import schedstate, schedule
 from celery.utils.time import maybe_timedelta
 from redis import CredentialProvider
-from redis.exceptions import ConnectionError, ResponseError
+from redis.exceptions import ConnectionError
 
 from redbeat import RedBeatScheduler
 from redbeat.schedulers import (
-    RedBeatKeyExpiryError,
     RedBeatSchedulerEntry,
     RetryingConnection,
     acquire_distributed_beat_lock,
-    check_key_expiry,
     ensure_conf,
     get_redis,
 )
@@ -699,85 +697,6 @@ class RedBeatStartupAcquiresLock(RedBeatSchedulerTestBase):
 
         self.assertIsNone(self.s.lock)
         self.assertIsNone(get_redis(app=self.app).get(self.s.lock_key))
-
-
-class test_key_expiry_check(RedBeatCase):
-    def setup(self):
-        super().setup()
-        self.conf = ensure_conf(self.app)
-        self.redis = self.app.redbeat_redis
-
-    def check(self, maxmemory=None, policy=None, mode=None):
-        # fakeredis has no CONFIG GET, so a reply is stubbed in; passing no
-        # settings leaves it raising, as a Redis that hides CONFIG does
-        if mode is not None:
-            self.conf.key_expiry_check = mode
-
-        if maxmemory is None and policy is None:
-            return check_key_expiry(self.app)
-
-        config = {'maxmemory': str(maxmemory), 'maxmemory-policy': policy}
-        with patch.object(self.redis, 'config_get', return_value=config):
-            return check_key_expiry(self.app)
-
-    def test_nothing_to_report_by_default(self):
-        self.assertEqual(self.check(maxmemory=0, policy='noeviction'), [])
-
-    def test_evicting_policy_is_reported(self):
-        findings = self.check(maxmemory=100000, policy='allkeys-lru')
-
-        self.assertEqual(len(findings), 1)
-        self.assertIn('allkeys-lru', findings[0])
-
-    def test_evicting_policy_without_a_memory_limit_is_ignored(self):
-        self.assertEqual(self.check(maxmemory=0, policy='allkeys-lru'), [])
-
-    def test_volatile_policy_is_ignored(self):
-        self.assertEqual(self.check(maxmemory=100000, policy='volatile-lru'), [])
-
-    def test_findings_are_logged_as_errors(self):
-        with self.assertLogs('celery.beat', level='ERROR') as cm:
-            self.check(maxmemory=100000, policy='allkeys-lru')
-
-        self.assertTrue(any('allkeys-lru' in message for message in cm.output))
-
-    def test_warn_mode_logs_a_warning(self):
-        with self.assertLogs('celery.beat', level='WARNING') as cm:
-            self.check(maxmemory=100000, policy='allkeys-lru', mode='warn')
-
-        self.assertTrue(all(record.startswith('WARNING') for record in cm.output))
-
-    def test_raise_mode_raises(self):
-        with self.assertRaises(RedBeatKeyExpiryError):
-            self.check(maxmemory=100000, policy='allkeys-lru', mode='raise')
-
-    def test_raise_mode_is_quiet_when_nothing_is_wrong(self):
-        self.assertEqual(self.check(maxmemory=0, policy='noeviction', mode='raise'), [])
-
-    def test_ignore_mode_asks_redis_nothing(self):
-        with patch.object(self.redis, 'config_get') as config_get:
-            self.assertEqual(self.check(mode='ignore'), [])
-
-        self.assertFalse(config_get.called)
-
-    def test_unreadable_config_is_not_a_finding(self):
-        with self.assertRaises(ResponseError):
-            self.redis.config_get('maxmemory*')
-
-        with self.assertLogs('celery.beat', level='WARNING'):
-            self.assertEqual(self.check(mode='raise'), [])
-
-    def test_cluster_config_reply_is_reported_per_node(self):
-        config = {
-            'node-1': {'maxmemory': '100000', 'maxmemory-policy': 'noeviction'},
-            'node-2': {'maxmemory': '100000', 'maxmemory-policy': 'allkeys-lfu'},
-        }
-        with patch.object(self.redis, 'config_get', return_value=config):
-            findings = check_key_expiry(self.app)
-
-        self.assertEqual(len(findings), 1)
-        self.assertIn('node-2', findings[0])
-        self.assertIn('allkeys-lfu', findings[0])
 
 
 class test_key_expiry_check_at_startup(RedBeatCase):


### PR DESCRIPTION
## What & why

Follow-up to #331, which raised the "Failed to load, removing" log to `ERROR`.
That message still arrives after the damage and says nothing about cause.

RedBeat's keys are the schedule, not a cache of it. Nothing recreates them: an
entry whose hash disappears stops running, and entries created through the API
are gone for good. With `maxmemory` set and a `maxmemory-policy` in the
`allkeys-*` family, Redis may drop any of them under memory pressure — the case
#291 hit. Nothing in RedBeat said that was a problem, or checked.

## Change

`RedBeatScheduler.__init__` now reads `maxmemory-policy` once and reports an
evicting one, in the log and in the beat banner. New `redbeat_key_expiry_check`
setting chooses what a finding does: `ignore`, `warn`, `error` (default) or
`raise`. The check itself lives in a new `redbeat/checks.py` and takes a client
and a mode, so it depends on nothing in `schedulers.py`.

Deliberate limits:

- **One `CONFIG GET` at startup, nothing per tick.** Key TTLs are not read back
  — that would be a round trip per entry — so the docs carry a redis-cli recipe
  for sweeping `redbeat:*` by hand.
- **`volatile-*` is not reported.** Those policies only evict keys carrying an
  expiry, and the only expiry RedBeat sets is on `redbeat::lock`, which is meant
  to expire; that is what releases the lock when a beat process dies.
- **A server that will not answer is not called unsafe.** `CONFIG` is disabled
  or renamed on several managed Redis offerings, so the default logs a warning
  and starts. `'raise'` is the exception: it is strict and opt-in, so it refuses
  to start rather than run on a server it could not clear.
- **Cluster replies are read per node**, and findings are grouped by policy, so
  an all-evicting cluster logs one line rather than one per node.
- **No behaviour change on upgrade.** The default logs and starts, as before.

Self-healing static entries from `beat_schedule`, the other half of #291, is
deliberately left out — recreating a deliberately deleted entry is a behaviour
change that deserves its own review.

New docs: a `Redis requirements` section in `docs/config.rst` covering safe
policies, the lock-key exception, what the check does and does not cover, and
the manual sweep.

## Test plan

- New `tests/test_checks.py` drives the check off a stub client: the evicting
  and non-evicting policies, `maxmemory 0`, `volatile-*`, unparsable values, all
  four modes, the three cluster shapes (one bad node, several sharing a policy,
  several differing), and the unreadable-`CONFIG` path in both postures.
- `tests/test_scheduler.py` keeps the banner assertions; `tests/test_config.py`
  covers the setting's parsing and fallback.
- `make test` passes (111 tests), `make lint` clean, `make docs` builds with no
  new warnings.

Refs #291