### PR TITLE
Expose package version and fix docs build configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,10 +27,9 @@ sphinx:
 #    - pdf
 #    - epub
 
-# Read the Docs no longer installs the package by default, so declare it
-# explicitly -- without this, Sphinx builds against an environment lacking
-# celery-redbeat and its dependencies.
-python:
-  install:
-    - method: pip
-      path: .
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,9 +27,10 @@ sphinx:
 #    - pdf
 #    - epub
 
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+# Read the Docs no longer installs the package by default, so declare it
+# explicitly -- without this, Sphinx builds against an environment lacking
+# celery-redbeat and its dependencies.
+python:
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,9 +27,9 @@ sphinx:
 #    - pdf
 #    - epub
 
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+# docs/conf.py imports redbeat to read __version__, so the package must be
+# installed before Sphinx runs.
+python:
+  install:
+    - method: pip
+      path: .

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,10 @@
   - doc, document how to list every stored entry, and note that
     `RedBeatScheduler.schedule` is a due-window query rather than the whole
     schedule, fixes #155
+  - bugfix, expose `redbeat.__version__` (via package metadata) and use it
+    in docs/conf.py, so built docs show a real version instead of a blank
+    one; declare `python.install` in .readthedocs.yaml so Read the Docs
+    installs the package before Sphinx imports it
 2.4.2 (2026-07-27)
 ---------------------
   - bugfix, restore the pre-2.4.0 handling of options inherited from

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,9 +13,6 @@
   - doc, document how to list every stored entry, and note that
     `RedBeatScheduler.schedule` is a due-window query rather than the whole
     schedule, fixes #155
-  - bugfix, declare `python.install` in .readthedocs.yaml so Read the Docs
-    installs celery-redbeat and its dependencies before building the docs,
-    since it no longer does so by default
 2.4.2 (2026-07-27)
 ---------------------
   - bugfix, restore the pre-2.4.0 handling of options inherited from

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,9 @@
   - doc, document how to list every stored entry, and note that
     `RedBeatScheduler.schedule` is a due-window query rather than the whole
     schedule, fixes #155
+  - bugfix, declare `python.install` in .readthedocs.yaml so Read the Docs
+    installs celery-redbeat and its dependencies before building the docs,
+    since it no longer does so by default
 2.4.2 (2026-07-27)
 ---------------------
   - bugfix, restore the pre-2.4.0 handling of options inherited from

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,14 +18,15 @@
 
 # -- Project information -----------------------------------------------------
 
+from redbeat import __version__ as release
+
 project = 'Celery Redbeat'
 copyright = '2019, Marc Sibson'
 author = 'Marc Sibson'
 
 # The short X.Y version
-version = ''
-# The full version, including alpha/beta/rc tags
-release = ''
+version = '.'.join(release.split('.')[:2])
+# The full version, including alpha/beta/rc tags, is imported as `release` above
 
 
 # -- General configuration ---------------------------------------------------

--- a/redbeat/__init__.py
+++ b/redbeat/__init__.py
@@ -1,2 +1,10 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from .checks import RedBeatKeyExpiryError  # noqa
 from .schedulers import RedBeatScheduler, RedBeatSchedulerEntry  # noqa
+
+try:
+    __version__ = version('celery-redbeat')
+except PackageNotFoundError:
+    # not installed, e.g. running tests straight from a checkout
+    __version__ = '0.0.0'


### PR DESCRIPTION
## Summary

This change exposes the package version via `redbeat.__version__` and updates the documentation build configuration to use it, ensuring built docs display the actual version instead of a blank string.

## Changes

- **redbeat/__init__.py**: Added dynamic version detection using `importlib.metadata.version()`, falling back to '0.0.0' when the package is not installed (e.g., during development)
- **docs/conf.py**: Updated to import `__version__` from the redbeat package and derive both `version` and `release` from it, replacing hardcoded empty strings
- **.readthedocs.yaml**: Uncommented and configured `python.install` to ensure the redbeat package is installed before Sphinx runs, since `docs/conf.py` now imports from it
- **CHANGES.txt**: Added changelog entry documenting the bugfix

## Implementation Details

The version is now sourced from package metadata rather than being hardcoded, which ensures consistency between the installed package and documentation. The fallback to '0.0.0' handles cases where the package hasn't been installed yet (such as running tests from a fresh checkout).

The Read the Docs configuration change is necessary because `docs/conf.py` now has a direct import dependency on the redbeat package at module load time, requiring it to be installed before the Sphinx build begins.

https://claude.ai/code/session_01G6evVezvHQ8oPfkMotdWCC