### PR TITLE
bugfix: warn instead of raising when beat_init fires with another scheduler

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 2.4.3 (unreleased)
 ---------------------
+  - bugfix, the beat_init receiver logs a warning naming -S redbeat.RedBeatScheduler
+    and returns when beat runs another scheduler, instead of raising
+    AttributeError on lock_key, fixes #342
   - feature, check at startup for a Redis maxmemory-policy that can evict
     RedBeat's keys, and report it in the log and the beat banner; controlled
     by redbeat_key_expiry_check, #291

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -675,6 +675,13 @@ def acquire_distributed_beat_lock(sender=None, **kwargs):
     scheduler.lock will be None while scheduler.lock_key is set
     """
     scheduler = sender.scheduler
+    if not isinstance(scheduler, RedBeatScheduler):
+        logger.warning(
+            'beat: redbeat is imported but beat runs %s; start beat with '
+            '-S redbeat.RedBeatScheduler to use RedBeat',
+            type(scheduler).__name__,
+        )
+        return
     if not scheduler.lock_key:
         return
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -699,6 +699,22 @@ class RedBeatStartupAcquiresLock(RedBeatSchedulerTestBase):
         self.assertIsNone(get_redis(app=self.app).get(self.s.lock_key))
 
 
+class OtherScheduler:
+    pass
+
+
+class RedBeatStartupWithAnotherScheduler(RedBeatCase):
+    def test_warns_and_returns_instead_of_raising(self):
+        sender = Mock(scheduler=OtherScheduler())
+
+        with self.assertLogs('celery.beat', level='WARNING') as logs:
+            acquire_distributed_beat_lock(sender)
+
+        self.assertEqual(1, len(logs.output))
+        self.assertIn('OtherScheduler', logs.output[0])
+        self.assertIn('-S redbeat.RedBeatScheduler', logs.output[0])
+
+
 class test_key_expiry_check_at_startup(RedBeatCase):
     def test_findings_appear_in_the_beat_banner(self):
         config = {'maxmemory': '100000', 'maxmemory-policy': 'allkeys-lru'}


### PR DESCRIPTION
Fixes #342

`acquire_distributed_beat_lock` reads `sender.scheduler.lock_key`. When redbeat is imported but `celery beat` runs without `-S redbeat.RedBeatScheduler`, the scheduler is Celery's `PersistentScheduler`, the receiver raises `AttributeError: 'PersistentScheduler' object has no attribute 'lock_key'`, and Celery logs the traceback at startup. Beat then keeps running on the wrong scheduler, so the only hint that RedBeat is not in use is a confusing stack trace. #87 and #276 are both this misconfiguration and both ended with "pass --scheduler".

This returns early when the scheduler is not a `RedBeatScheduler` and logs a single warning that names the flag. Not a silent guard on purpose: the misconfiguration stays visible, just as one line instead of a traceback.

Test in tests/test_scheduler.py (`RedBeatStartupWithAnotherScheduler`), errors on main. CHANGES.txt entry under 2.4.3 (unreleased). `make test` 112 OK, `make lint` clean.
